### PR TITLE
feature/advanced-authenticator-selection

### DIFF
--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -4,12 +4,9 @@ test('should generate credential request options suitable for sending via JSON',
   const challenge = 'totallyrandomvalue';
 
   const options = generateAssertionOptions({
-    challenge,
+    ...goodOpts1,
     timeout: 1,
-    allowedBase64CredentialIDs: [
-      Buffer.from('1234', 'ascii').toString('base64'),
-      Buffer.from('5678', 'ascii').toString('base64'),
-    ],
+    challenge,
   });
 
   expect(options).toEqual({
@@ -31,13 +28,32 @@ test('should generate credential request options suitable for sending via JSON',
 });
 
 test('defaults to 60 seconds if no timeout is specified', () => {
-  const options = generateAssertionOptions({
-    challenge: 'totallyrandomvalue',
-    allowedBase64CredentialIDs: [
-      Buffer.from('1234', 'ascii').toString('base64'),
-      Buffer.from('5678', 'ascii').toString('base64'),
-    ],
-  });
+  const options = generateAssertionOptions(goodOpts1);
 
   expect(options.timeout).toEqual(60000);
 });
+
+test('should not set userVerification if not specified', () => {
+  const options = generateAssertionOptions({
+    ...goodOpts1,
+  });
+
+  expect(options.userVerification).toEqual(undefined);
+});
+
+test('should set userVerification if specified', () => {
+  const options = generateAssertionOptions({
+    ...goodOpts1,
+    userVerification: 'required',
+  });
+
+  expect(options.userVerification).toEqual('required');
+});
+
+const goodOpts1 = {
+  challenge: 'totallyrandomvalue',
+  allowedBase64CredentialIDs: [
+    Buffer.from('1234', 'ascii').toString('base64'),
+    Buffer.from('5678', 'ascii').toString('base64'),
+  ],
+};

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -7,6 +7,7 @@ type Options = {
   allowedBase64CredentialIDs: string[],
   suggestedTransports?: AuthenticatorTransport[],
   timeout?: number,
+  userVerification?: UserVerificationRequirement,
 };
 
 /**
@@ -17,6 +18,8 @@ type Options = {
  * user for assertion
  * @param timeout How long (in ms) the user can take to complete assertion
  * @param suggestedTransports Suggested types of authenticators for assertion
+ * @param userVerification Set to `'discouraged'` when asserting as part of a 2FA flow, otherwise
+ * set to `'preferred'` or `'required'` as desired.
  */
 export default function generateAssertionOptions(
   options: Options,
@@ -26,6 +29,7 @@ export default function generateAssertionOptions(
     allowedBase64CredentialIDs,
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     timeout = 60000,
+    userVerification,
   } = options;
 
   return {
@@ -36,5 +40,6 @@ export default function generateAssertionOptions(
       transports: suggestedTransports,
     })),
     timeout,
+    userVerification,
   };
 }

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -83,14 +83,14 @@ test('defaults to direct attestation if no attestation type is specified', () =>
   expect(options.attestation).toEqual('none');
 });
 
-test('should set authenticatorAttributes to authenticatorSelection if set', () => {
+test('should set authenticatorSelection if specified', () => {
   const options = generateAttestationOptions({
     serviceName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
     userName: 'usernameHere',
-    authenticatorAttributes: {
+    authenticatorSelection: {
       authenticatorAttachment: 'cross-platform',
       requireResidentKey: false,
       userVerification: 'preferred',

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -82,3 +82,24 @@ test('defaults to direct attestation if no attestation type is specified', () =>
 
   expect(options.attestation).toEqual('none');
 });
+
+test('should set authenticatorAttributes to authenticatorSelection if set', () => {
+  const options = generateAttestationOptions({
+    serviceName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorAttributes: {
+      authenticatorAttachment: 'cross-platform',
+      requireResidentKey: false,
+      userVerification: 'preferred',
+    },
+  });
+
+  expect(options.authenticatorSelection).toEqual({
+    authenticatorAttachment: 'cross-platform',
+    requireResidentKey: false,
+    userVerification: 'preferred',
+  });
+});

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -13,6 +13,7 @@ type Options = {
   attestationType?: AttestationConveyancePreference,
   excludedBase64CredentialIDs?: string[],
   suggestedTransports?: AuthenticatorTransport[],
+  authenticatorAttributes?: AuthenticatorSelectionCriteria,
 };
 
 /**
@@ -31,6 +32,7 @@ type Options = {
  * @param excludedBase64CredentialIDs Array of base64-encoded authenticator IDs registered by the
  * user so the user can't register the same credential multiple times
  * @param suggestedTransports Suggested types of authenticators for attestation
+ * @param authenticatorAttributes Advanced criteria for the types of authenticators that may be used
  */
 export default function generateAttestationOptions(
   options: Options,
@@ -46,6 +48,7 @@ export default function generateAttestationOptions(
     attestationType = 'none',
     excludedBase64CredentialIDs = [],
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
+    authenticatorAttributes,
   } = options;
 
   return {
@@ -72,5 +75,6 @@ export default function generateAttestationOptions(
       type: 'public-key',
       transports: suggestedTransports,
     })),
+    authenticatorSelection: authenticatorAttributes,
   };
 }

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -13,7 +13,7 @@ type Options = {
   attestationType?: AttestationConveyancePreference,
   excludedBase64CredentialIDs?: string[],
   suggestedTransports?: AuthenticatorTransport[],
-  authenticatorAttributes?: AuthenticatorSelectionCriteria,
+  authenticatorSelection?: AuthenticatorSelectionCriteria,
 };
 
 /**
@@ -32,7 +32,8 @@ type Options = {
  * @param excludedBase64CredentialIDs Array of base64-encoded authenticator IDs registered by the
  * user so the user can't register the same credential multiple times
  * @param suggestedTransports Suggested types of authenticators for attestation
- * @param authenticatorAttributes Advanced criteria for the types of authenticators that may be used
+ * @param authenticatorSelection Advanced criteria for restricting the types of authenticators that
+ * may be used
  */
 export default function generateAttestationOptions(
   options: Options,
@@ -48,7 +49,7 @@ export default function generateAttestationOptions(
     attestationType = 'none',
     excludedBase64CredentialIDs = [],
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
-    authenticatorAttributes,
+    authenticatorSelection,
   } = options;
 
   return {
@@ -75,6 +76,6 @@ export default function generateAttestationOptions(
       type: 'public-key',
       transports: suggestedTransports,
     })),
-    authenticatorSelection: authenticatorAttributes,
+    authenticatorSelection,
   };
 }


### PR DESCRIPTION
This PR adds support for specifying the optional [`authenticatorSelection`](https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-authenticatorselection) value in `generateAttestationOptions()`.

Also included is support for the optional `userVerification` flag in `generateAssertionOptions()`. This should address #12.