### PR TITLE
feature/extensions-support

### DIFF
--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -34,9 +34,7 @@ test('defaults to 60 seconds if no timeout is specified', () => {
 });
 
 test('should not set userVerification if not specified', () => {
-  const options = generateAssertionOptions({
-    ...goodOpts1,
-  });
+  const options = generateAssertionOptions(goodOpts1);
 
   expect(options.userVerification).toEqual(undefined);
 });
@@ -48,6 +46,17 @@ test('should set userVerification if specified', () => {
   });
 
   expect(options.userVerification).toEqual('required');
+});
+
+test('should set extensions if specified', () => {
+  const options = generateAssertionOptions({
+    ...goodOpts1,
+    extensions: { appid: 'simplewebauthn' },
+  });
+
+  expect(options.extensions).toEqual({
+    appid: 'simplewebauthn',
+  });
 });
 
 const goodOpts1 = {

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -8,6 +8,7 @@ type Options = {
   suggestedTransports?: AuthenticatorTransport[],
   timeout?: number,
   userVerification?: UserVerificationRequirement,
+  extensions?: AuthenticationExtensionsClientInputs,
 };
 
 /**
@@ -20,6 +21,7 @@ type Options = {
  * @param suggestedTransports Suggested types of authenticators for assertion
  * @param userVerification Set to `'discouraged'` when asserting as part of a 2FA flow, otherwise
  * set to `'preferred'` or `'required'` as desired.
+ * @param extensions Additional plugins the authenticator or browser should use during assertion
  */
 export default function generateAssertionOptions(
   options: Options,
@@ -30,6 +32,7 @@ export default function generateAssertionOptions(
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     timeout = 60000,
     userVerification,
+    extensions,
   } = options;
 
   return {
@@ -41,5 +44,6 @@ export default function generateAssertionOptions(
     })),
     timeout,
     userVerification,
+    extensions,
   };
 }

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -71,7 +71,7 @@ test('defaults to 60 seconds if no timeout is specified', () => {
   expect(options.timeout).toEqual(60000);
 });
 
-test('defaults to direct attestation if no attestation type is specified', () => {
+test('defaults to none attestation if no attestation type is specified', () => {
   const options = generateAttestationOptions({
     serviceName: 'SimpleWebAuthn',
     rpID: 'not.real',
@@ -101,5 +101,20 @@ test('should set authenticatorSelection if specified', () => {
     authenticatorAttachment: 'cross-platform',
     requireResidentKey: false,
     userVerification: 'preferred',
+  });
+});
+
+test('should set extensions if specified', () => {
+  const options = generateAttestationOptions({
+    serviceName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userID: '1234',
+    userName: 'usernameHere',
+    extensions: { appid: 'simplewebauthn' },
+  });
+
+  expect(options.extensions).toEqual({
+    appid: 'simplewebauthn',
   });
 });

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -14,6 +14,7 @@ type Options = {
   excludedBase64CredentialIDs?: string[],
   suggestedTransports?: AuthenticatorTransport[],
   authenticatorSelection?: AuthenticatorSelectionCriteria,
+  extensions?: AuthenticationExtensionsClientInputs,
 };
 
 /**
@@ -34,6 +35,7 @@ type Options = {
  * @param suggestedTransports Suggested types of authenticators for attestation
  * @param authenticatorSelection Advanced criteria for restricting the types of authenticators that
  * may be used
+ * @param extensions Additional plugins the authenticator or browser should use during attestation
  */
 export default function generateAttestationOptions(
   options: Options,
@@ -50,6 +52,7 @@ export default function generateAttestationOptions(
     excludedBase64CredentialIDs = [],
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     authenticatorSelection,
+    extensions,
   } = options;
 
   return {
@@ -77,5 +80,6 @@ export default function generateAttestationOptions(
       transports: suggestedTransports,
     })),
     authenticatorSelection,
+    extensions,
   };
 }


### PR DESCRIPTION
This PR adds support for passing in `extensions` into `generateAttestationOptions()` and `generateAssertionOptions()`.