### PR TITLE
feature/example-mkcert

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -12,13 +12,15 @@ Websites that wish to leverage WebAuthn _must_ be served over HTTPS, **including
 
 Here's one technique for setting up SSL for a local dev instance:
 
-1. Create a `dev` A-record in `yourdomain.com`'s DNS settings that points to `127.0.0.1`
-2. Use EFF's [certbot](https://certbot.eff.org/) locally to generate a .crt and .key for that `dev` subdomain
-3. Update `key` and `cert` passed into `https.createServer()` to point to your custom certificates
+1. [Install mkcert](https://github.com/FiloSottile/mkcert#installation) as per its instructions
+2. Run `mkcert -install` to initialize mkcert
+3. Generate SSL certificates for localhost:
+
+> ./example/ $> **mkcert -key-file localhost.key -cert-file localhost.crt localhost**
 
 ## Instructions
 
 1. Set up your SSL certificates as above
 2. Install dependencies with `npm install`
 3. Start the server with `npm start`
-4. Navigate to `https://dev.yourdomain.com`
+4. Navigate to https://localhost

--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -83,8 +83,8 @@ const fidoComplianceRouter = express.Router();
 
 let loggedInUsername = undefined;
 const serviceName = 'FIDO Conformance Test';
-const rpID = 'dev.dontneeda.pw';
-const origin = 'https://dev.dontneeda.pw';
+const rpID = 'localhost';
+const origin = 'https://localhost';
 
 /**
  * [FIDO2] Server Tests > MakeCredential Request

--- a/example/index.js
+++ b/example/index.js
@@ -39,7 +39,7 @@ app.use(express.json());
  * RP ID represents the "scope" of websites on which a authenticator should be usable. The Origin
  * represents the expected URL from which an attestation or assertion occurs.
  */
-const rpID = 'dev.yourdomain.com';
+const rpID = 'localhost';
 const origin = `https://${rpID}`;
 /**
  * 2FA and Passwordless WebAuthn flows expect you to be able to uniquely identify the user that
@@ -84,7 +84,7 @@ const loggedInUserId = 'internalUserId';
 const inMemoryUserDeviceDB = {
   [loggedInUserId]: {
     id: loggedInUserId,
-    username: 'user@yourdomain.com',
+    username: 'user@localhost',
     devices: [
       /**
        * {
@@ -272,14 +272,10 @@ https
   .createServer(
     {
       /**
-       * You'll need to provide a SSL cert and key here because
-       * WebAuthn can only be run from HTTPS:// URLs
-       *
-       * HINT: If you create a `dev` subdomain A-record that points to 127.0.0.1,
-       * you can manually generate an HTTPS certificate for it using Let's Encrypt certbot.
+       * WebAuthn can only be run from https:// URLs. See the README on how to generate this SSL cert and key pair using mkcert
        */
-      key: fs.readFileSync('./dev.yourdomain.com.key'),
-      cert: fs.readFileSync('./dev.yourdomain.com.crt'),
+      key: fs.readFileSync('./localhost.key'),
+      cert: fs.readFileSync('./localhost.crt'),
     },
     app,
   )


### PR DESCRIPTION
This PR contains changes to the Example project that enable everyone to host it at https://localhost.

This was achieved by leveraging [mkcert](https://github.com/FiloSottile/mkcert) instead of certbot. This dev CA application obviates the need to juggle custom subdomains, and simplifies the SSL cert procurement process.