### PR TITLE
feature/example-fido-mds-query

### DIFF
--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -40,7 +40,6 @@ try {
       statements.push(JSON.parse(contents));
     }
   }
-  console.log('initializing metadata service with', conformanceMetadataFilenames);
 } catch (err) {
   // pass
 }
@@ -66,6 +65,13 @@ fetch('https://fidoalliance.co.nz/mds/getEndpoints', {
       statements,
       mdsServers,
     });
+  })
+  .finally(() => {
+    if (statements.length) {
+      console.log(
+        `ℹ️  Initializing metadata service with ${statements.length} local statements`,
+      );
+    }
 
     console.log('🔐 FIDO Conformance routes ready');
   });

--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -13,6 +13,10 @@ const {
   MetadataService,
 } = require('@simplewebauthn/server');
 
+const serviceName = 'FIDO Conformance Test';
+const rpID = 'localhost';
+const origin = 'https://localhost';
+
 /**
  * Load JSON metadata statements provided by the Conformance Tools
  *
@@ -82,9 +86,6 @@ const inMemoryUserDeviceDB = {
 const fidoComplianceRouter = express.Router();
 
 let loggedInUsername = undefined;
-const serviceName = 'FIDO Conformance Test';
-const rpID = 'localhost';
-const origin = 'https://localhost';
 
 /**
  * [FIDO2] Server Tests > MakeCredential Request

--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -13,9 +13,16 @@ const {
   MetadataService,
 } = require('@simplewebauthn/server');
 
+
+/**
+ * Create paths specifically for testing with the FIDO Conformance Tools
+ */
+const fidoConformanceRouter = express.Router();
+
 const serviceName = 'FIDO Conformance Test';
 const rpID = 'localhost';
 const origin = 'https://localhost';
+const fidoRouteSuffix = '/fido';
 
 /**
  * Load JSON metadata statements provided by the Conformance Tools
@@ -79,18 +86,13 @@ const inMemoryUserDeviceDB = {
   //   currentAssertionUserVerification: undefined,
   // },
 };
-
-/**
- * Create paths specifically for testing with the FIDO Conformance Tools
- */
-const fidoComplianceRouter = express.Router();
-
+// A cheap way of remembering who's "logged in" between the request for options and the response
 let loggedInUsername = undefined;
 
 /**
  * [FIDO2] Server Tests > MakeCredential Request
  */
-fidoComplianceRouter.post('/attestation/options', (req, res) => {
+fidoConformanceRouter.post('/attestation/options', (req, res) => {
   const { body } = req;
   const { username, displayName, authenticatorSelection, attestation, extensions } = body;
 
@@ -136,7 +138,7 @@ fidoComplianceRouter.post('/attestation/options', (req, res) => {
 /**
  * [FIDO2] Server Tests > MakeCredential Response
  */
-fidoComplianceRouter.post('/attestation/result', async (req, res) => {
+fidoConformanceRouter.post('/attestation/result', async (req, res) => {
   const { body } = req;
 
   const user = inMemoryUserDeviceDB[loggedInUsername];
@@ -183,7 +185,7 @@ fidoComplianceRouter.post('/attestation/result', async (req, res) => {
 /**
  * [FIDO2] Server Tests > GetAssertion Request
  */
-fidoComplianceRouter.post('/assertion/options', (req, res) => {
+fidoConformanceRouter.post('/assertion/options', (req, res) => {
   const { body } = req;
   const { username, userVerification, extensions } = body;
 
@@ -211,7 +213,7 @@ fidoComplianceRouter.post('/assertion/options', (req, res) => {
   });
 });
 
-fidoComplianceRouter.post('/assertion/result', (req, res) => {
+fidoConformanceRouter.post('/assertion/result', (req, res) => {
   const { body } = req;
   const { id } = body;
 
@@ -256,7 +258,7 @@ fidoComplianceRouter.post('/assertion/result', (req, res) => {
  * A catch-all for future test routes we might need to support but haven't yet defined (helps with
  * discovering which routes, what methods, and what data need to be defined)
  */
-fidoComplianceRouter.all('*', (req, res, next) => {
+fidoConformanceRouter.all('*', (req, res, next) => {
   console.log(req.url);
   console.log(req.method);
   console.log(req.body);
@@ -264,4 +266,7 @@ fidoComplianceRouter.all('*', (req, res, next) => {
   next();
 });
 
-module.exports = fidoComplianceRouter;
+module.exports = {
+  fidoConformanceRouter,
+  fidoRouteSuffix,
+};

--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -28,10 +28,10 @@ const fidoRouteSuffix = '/fido';
  *
  * FIDO2 > TESTS CONFIGURATION > DOWNLOAD SERVER METADATA (button)
  */
-// Update this to whatever folder you extracted the statements to
 const statements = [];
 
 try {
+  // Update this to whatever folder you extracted the statements to
   const conformanceMetadataPath = './fido-conformance-mds-v1.3.4';
   const conformanceMetadataFilenames = fs.readdirSync(conformanceMetadataPath);
   for (const statementPath of conformanceMetadataFilenames) {

--- a/example/fido-conformance.js
+++ b/example/fido-conformance.js
@@ -2,8 +2,6 @@
 const fs = require('fs');
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
-
-require('dotenv').config();
 const fetch = require('node-fetch');
 
 const {

--- a/example/index.js
+++ b/example/index.js
@@ -32,8 +32,8 @@ app.use(express.json());
  * FIDO Metadata Service. This enables greater control over the types of authenticators that can
  * interact with the Rely Party (a.k.a. "RP", a.k.a. "this server").
  */
-const { fidoRouteSuffix, fidoConformanceRouter } = require('./fido-conformance');
-app.use(fidoRouteSuffix, fidoConformanceRouter);
+// const { fidoRouteSuffix, fidoConformanceRouter } = require('./fido-conformance');
+// app.use(fidoRouteSuffix, fidoConformanceRouter);
 
 /**
  * RP ID represents the "scope" of websites on which a authenticator should be usable. The Origin

--- a/example/index.js
+++ b/example/index.js
@@ -32,8 +32,8 @@ app.use(express.json());
  * FIDO Metadata Service. This enables greater control over the types of authenticators that can
  * interact with the Rely Party (a.k.a. "RP", a.k.a. "this server").
  */
-// const FIDOConformanceRoutes = require('./fido-conformance');
-// app.use('/fido', FIDOConformanceRoutes);
+const { fidoRouteSuffix, fidoConformanceRouter } = require('./fido-conformance');
+app.use(fidoRouteSuffix, fidoConformanceRouter);
 
 /**
  * RP ID represents the "scope" of websites on which a authenticator should be usable. The Origin

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -502,11 +502,6 @@
         "is-obj": "^2.0.0"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "@simplewebauthn/server": "^0.7.1",
-    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.0"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@simplewebauthn/server": "^0.7.1",
     "dotenv": "^8.2.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.4",


### PR DESCRIPTION
This PR updates the example project to add a dynamic query to https://fidoalliance.co.nz/mds/ when initializing FIDO conformance routes. This query gets back an array of five URLs to domain-specific metadata statements that need to be used when running the FIDO Conformance tests. This simplifies the amount of work needed for others wishing to independently reproduce FIDO conformance test results.