### PR TITLE
feature/better-challenges

### DIFF
--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -4,6 +4,8 @@ import {
 } from '@simplewebauthn/typescript-types';
 
 import supportsWebauthn from '../helpers/supportsWebauthn';
+import toUint8Array from '../helpers/toUint8Array';
+import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
 import startAssertion from './startAssertion';
 
@@ -19,7 +21,7 @@ const mockUserHandle = 'mockUserHandle';
 
 // With ASCII challenge
 const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: 'fizz',
+  challenge: bufferToBase64URLString(toUint8Array('fizz')),
   allowCredentials: [
     {
       id: 'C0VGlvYFratUdAV1iCw-ULpUW8E-exHPXQChBfyVeJZCMfjMFcwDmOFgoMUz39LoMtCJUBW8WPlLkGT6q8qTCg',
@@ -32,7 +34,7 @@ const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
 
 // With UTF-8 challenge
 const goodOpts2UTF8: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: 'やれやれだぜ',
+  challenge: bufferToBase64URLString(toUint8Array('やれやれだぜ')),
   allowCredentials: [],
   timeout: 1,
 };
@@ -62,7 +64,7 @@ test('should convert options before passing to navigator.credentials.get(...)', 
   const argsPublicKey = mockNavigatorGet.mock.calls[0][0].publicKey;
   const credId = argsPublicKey.allowCredentials[0].id;
 
-  expect(JSON.stringify(argsPublicKey.challenge)).toEqual('{"0":102,"1":105,"2":122,"3":122}');
+  expect(new Uint8Array(argsPublicKey.challenge)).toEqual(new Uint8Array([102, 105, 122, 122]));
   // Make sure the credential ID is an ArrayBuffer with a length of 64
   expect(credId instanceof ArrayBuffer).toEqual(true);
   expect(credId.byteLength).toEqual(64);
@@ -148,8 +150,27 @@ test('should handle UTF-8 challenges', async done => {
 
   const argsPublicKey = mockNavigatorGet.mock.calls[0][0].publicKey;
 
-  expect(JSON.stringify(argsPublicKey.challenge)).toEqual(
-    '{"0":227,"1":130,"2":132,"3":227,"4":130,"5":140,"6":227,"7":130,"8":132,"9":227,"10":130,"11":140,"12":227,"13":129,"14":160,"15":227,"16":129,"17":156}',
+  expect(new Uint8Array(argsPublicKey.challenge)).toEqual(
+    new Uint8Array([
+      227,
+      130,
+      132,
+      227,
+      130,
+      140,
+      227,
+      130,
+      132,
+      227,
+      130,
+      140,
+      227,
+      129,
+      160,
+      227,
+      129,
+      156,
+    ]),
   );
 
   done();

--- a/packages/browser/src/methods/startAssertion.ts
+++ b/packages/browser/src/methods/startAssertion.ts
@@ -4,8 +4,8 @@ import {
   AssertionCredentialJSON,
 } from '@simplewebauthn/typescript-types';
 
-import toUint8Array from '../helpers/toUint8Array';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
+import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
@@ -24,14 +24,12 @@ export default async function startAssertion(
   // We need to convert some values to Uint8Arrays before passing the credentials to the navigator
   const publicKey: PublicKeyCredentialRequestOptions = {
     ...requestOptionsJSON,
-    challenge: toUint8Array(requestOptionsJSON.challenge),
-    allowCredentials: requestOptionsJSON.allowCredentials.map(
-      toPublicKeyCredentialDescriptor,
-    ),
+    challenge: base64URLStringToBuffer(requestOptionsJSON.challenge),
+    allowCredentials: requestOptionsJSON.allowCredentials.map(toPublicKeyCredentialDescriptor),
   };
 
   // Wait for the user to complete assertion
-  const credential = await navigator.credentials.get({ publicKey }) as AssertionCredential;
+  const credential = (await navigator.credentials.get({ publicKey })) as AssertionCredential;
 
   if (!credential) {
     throw new Error('Assertion was not completed');

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -5,6 +5,7 @@ import {
 
 import toUint8Array from '../helpers/toUint8Array';
 import supportsWebauthn from '../helpers/supportsWebauthn';
+import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
 import startAttestation from './startAttestation';
 
@@ -17,7 +18,7 @@ const mockAttestationObject = 'mockAtte';
 const mockClientDataJSON = 'mockClie';
 
 const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
-  challenge: 'fizz',
+  challenge: bufferToBase64URLString(toUint8Array('fizz')),
   attestation: 'direct',
   pubKeyCredParams: [
     {
@@ -35,11 +36,13 @@ const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
     name: 'username',
   },
   timeout: 1,
-  excludeCredentials: [{
-    id: 'C0VGlvYFratUdAV1iCw-ULpUW8E-exHPXQChBfyVeJZCMfjMFcwDmOFgoMUz39LoMtCJUBW8WPlLkGT6q8qTCg',
-    type: 'public-key',
-    transports: ['internal'],
-  }],
+  excludeCredentials: [
+    {
+      id: 'C0VGlvYFratUdAV1iCw-ULpUW8E-exHPXQChBfyVeJZCMfjMFcwDmOFgoMUz39LoMtCJUBW8WPlLkGT6q8qTCg',
+      type: 'public-key',
+      transports: ['internal'],
+    },
+  ],
 };
 
 beforeEach(() => {
@@ -65,8 +68,8 @@ test('should convert options before passing to navigator.credentials.create(...)
   const credId = argsPublicKey.excludeCredentials[0].id;
 
   // Make sure challenge and user.id are converted to Buffers
-  expect(JSON.stringify(argsPublicKey.challenge)).toEqual('{"0":102,"1":105,"2":122,"3":122}');
-  expect(JSON.stringify(argsPublicKey.user.id)).toEqual('{"0":53,"1":54,"2":55,"3":56}');
+  expect(new Uint8Array(argsPublicKey.challenge)).toEqual(new Uint8Array([102, 105, 122, 122]));
+  expect(new Uint8Array(argsPublicKey.user.id)).toEqual(new Uint8Array([53, 54, 55, 56]));
 
   // Confirm construction of excludeCredentials array
   expect(credId instanceof ArrayBuffer).toEqual(true);

--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -6,6 +6,7 @@ import {
 
 import toUint8Array from '../helpers/toUint8Array';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
+import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
@@ -24,18 +25,16 @@ export default async function startAttestation(
   // We need to convert some values to Uint8Arrays before passing the credentials to the navigator
   const publicKey: PublicKeyCredentialCreationOptions = {
     ...creationOptionsJSON,
-    challenge: toUint8Array(creationOptionsJSON.challenge),
+    challenge: base64URLStringToBuffer(creationOptionsJSON.challenge),
     user: {
       ...creationOptionsJSON.user,
       id: toUint8Array(creationOptionsJSON.user.id),
     },
-    excludeCredentials: creationOptionsJSON.excludeCredentials.map(
-      toPublicKeyCredentialDescriptor,
-    ),
+    excludeCredentials: creationOptionsJSON.excludeCredentials.map(toPublicKeyCredentialDescriptor),
   };
 
   // Wait for the user to complete attestation
-  const credential = await navigator.credentials.create({ publicKey }) as AttestationCredential;
+  const credential = (await navigator.credentials.create({ publicKey })) as AttestationCredential;
 
   if (!credential) {
     throw new Error('Attestation was not completed');

--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -1,3 +1,5 @@
+import base64url from 'base64url';
+
 import generateAssertionOptions from './generateAssertionOptions';
 
 test('should generate credential request options suitable for sending via JSON', () => {
@@ -10,7 +12,7 @@ test('should generate credential request options suitable for sending via JSON',
   });
 
   expect(options).toEqual({
-    challenge,
+    challenge: base64url.encode(challenge),
     allowCredentials: [
       {
         id: 'MTIzNA==',

--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -1,4 +1,4 @@
-import base64url from 'base64url';
+jest.mock('../helpers/generateChallenge');
 
 import generateAssertionOptions from './generateAssertionOptions';
 
@@ -12,7 +12,8 @@ test('should generate credential request options suitable for sending via JSON',
   });
 
   expect(options).toEqual({
-    challenge: base64url.encode(challenge),
+    // base64url-encoded
+    challenge: 'dG90YWxseXJhbmRvbXZhbHVl',
     allowCredentials: [
       {
         id: 'MTIzNA==',
@@ -59,6 +60,16 @@ test('should set extensions if specified', () => {
   expect(options.extensions).toEqual({
     appid: 'simplewebauthn',
   });
+});
+
+test('should generate a challenge if one is not provided', () => {
+  const opts = { ...goodOpts1 };
+  delete opts.challenge;
+
+  const options = generateAssertionOptions(opts);
+
+  // base64url-encoded 16-byte buffer from mocked `generateChallenge()`
+  expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });
 
 const goodOpts1 = {

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -19,7 +19,7 @@ type Options = {
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator "login"
  *
  * @param allowedCredentialIDs Array of base64url-encoded authenticator IDs registered by the
- * @param challenge Random string the authenticator needs to sign and pass back
+ * @param challenge Random value the authenticator needs to sign and pass back
  * user for assertion
  * @param timeout How long (in ms) the user can take to complete assertion
  * @param suggestedTransports Suggested types of authenticators for assertion

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -2,10 +2,13 @@ import type {
   PublicKeyCredentialRequestOptionsJSON,
   Base64URLString,
 } from '@simplewebauthn/typescript-types';
+import base64url from 'base64url';
+
+import generateChallenge from '../helpers/generateChallenge';
 
 type Options = {
-  challenge: string;
   allowedCredentialIDs: Base64URLString[];
+  challenge?: string | Buffer;
   suggestedTransports?: AuthenticatorTransport[];
   timeout?: number;
   userVerification?: UserVerificationRequirement;
@@ -15,8 +18,8 @@ type Options = {
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator "login"
  *
- * @param challenge Random string the authenticator needs to sign and pass back
  * @param allowedCredentialIDs Array of base64url-encoded authenticator IDs registered by the
+ * @param challenge Random string the authenticator needs to sign and pass back
  * user for assertion
  * @param timeout How long (in ms) the user can take to complete assertion
  * @param suggestedTransports Suggested types of authenticators for assertion
@@ -28,8 +31,8 @@ export default function generateAssertionOptions(
   options: Options,
 ): PublicKeyCredentialRequestOptionsJSON {
   const {
-    challenge,
     allowedCredentialIDs,
+    challenge = generateChallenge(),
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     timeout = 60000,
     userVerification,
@@ -37,7 +40,7 @@ export default function generateAssertionOptions(
   } = options;
 
   return {
-    challenge,
+    challenge: base64url.encode(challenge),
     allowCredentials: allowedCredentialIDs.map(id => ({
       id,
       type: 'public-key',

--- a/packages/server/src/assertion/verifyAssertionResponse.test.ts
+++ b/packages/server/src/assertion/verifyAssertionResponse.test.ts
@@ -196,7 +196,7 @@ const assertionResponse = {
   getClientExtensionResults: () => ({}),
   type: 'public-key',
 };
-const assertionChallenge = 'totallyUniqueValueEveryTime';
+const assertionChallenge = base64url.encode('totallyUniqueValueEveryTime');
 const assertionOrigin = 'https://dev.dontneeda.pw';
 
 const authenticator = {
@@ -222,7 +222,7 @@ const assertionFirstTimeUsedResponse = {
   },
   type: 'public-key',
 };
-const assertionFirstTimeUsedChallenge = 'totallyUniqueValueEveryAssertion';
+const assertionFirstTimeUsedChallenge = base64url.encode('totallyUniqueValueEveryAssertion');
 const assertionFirstTimeUsedOrigin = 'https://dev.dontneeda.pw';
 const authenticatorFirstTimeUsed = {
   publicKey:

--- a/packages/server/src/assertion/verifyAssertionResponse.ts
+++ b/packages/server/src/assertion/verifyAssertionResponse.ts
@@ -23,8 +23,8 @@ type Options = {
  * **Options:**
  *
  * @param credential Authenticator credential returned by browser's `startAssertion()`
- * @param expectedChallenge The random value provided to generateAssertionOptions for the
- * authenticator to sign
+ * @param expectedChallenge The base64url-encoded `options.challenge` returned by
+ * `generateAssertionOptions()`
  * @param expectedOrigin Website URL that the attestation should have occurred on
  * @param expectedRPID RP ID that was specified in the attestation options
  * @param authenticator An internal {@link AuthenticatorDevice} matching the credential's ID
@@ -76,10 +76,9 @@ export default function verifyAssertionResponse(options: Options): VerifiedAsser
   }
 
   // Ensure the device provided the challenge we gave it
-  const encodedExpectedChallenge = base64url.encode(expectedChallenge);
-  if (challenge !== encodedExpectedChallenge) {
+  if (challenge !== expectedChallenge) {
     throw new Error(
-      `Unexpected assertion challenge "${challenge}", expected "${encodedExpectedChallenge}"`,
+      `Unexpected assertion challenge "${challenge}", expected "${expectedChallenge}"`,
     );
   }
 

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -1,4 +1,5 @@
 import generateAttestationOptions from './generateAttestationOptions';
+import base64url from 'base64url';
 
 test('should generate credential request options suitable for sending via JSON', () => {
   const serviceName = 'SimpleWebAuthn';
@@ -20,7 +21,7 @@ test('should generate credential request options suitable for sending via JSON',
   });
 
   expect(options).toEqual({
-    challenge,
+    challenge: base64url.encode(challenge),
     rp: {
       name: serviceName,
       id: rpID,
@@ -51,7 +52,7 @@ test('should map excluded credential IDs if specified', () => {
   const options = generateAttestationOptions({
     serviceName: 'SimpleWebAuthn',
     rpID: 'not.real',
-    challenge: 'totallyrandomvalue',
+    challenge: base64url.encode('totallyrandomvalue'),
     userID: '1234',
     userName: 'usernameHere',
     excludedCredentialIDs: ['someIDhere'],

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -1,5 +1,6 @@
+jest.mock('../helpers/generateChallenge');
+
 import generateAttestationOptions from './generateAttestationOptions';
-import base64url from 'base64url';
 
 test('should generate credential request options suitable for sending via JSON', () => {
   const serviceName = 'SimpleWebAuthn';
@@ -21,7 +22,8 @@ test('should generate credential request options suitable for sending via JSON',
   });
 
   expect(options).toEqual({
-    challenge: base64url.encode(challenge),
+    // Challenge, base64url-encoded
+    challenge: 'dG90YWxseXJhbmRvbXZhbHVl',
     rp: {
       name: serviceName,
       id: rpID,
@@ -52,7 +54,7 @@ test('should map excluded credential IDs if specified', () => {
   const options = generateAttestationOptions({
     serviceName: 'SimpleWebAuthn',
     rpID: 'not.real',
-    challenge: base64url.encode('totallyrandomvalue'),
+    challenge: 'totallyrandomvalue',
     userID: '1234',
     userName: 'usernameHere',
     excludedCredentialIDs: ['someIDhere'],
@@ -125,4 +127,16 @@ test('should set extensions if specified', () => {
   expect(options.extensions).toEqual({
     appid: 'simplewebauthn',
   });
+});
+
+test('should generate a challenge if one is not provided', () => {
+  const options = generateAttestationOptions({
+    rpID: 'not.real',
+    serviceName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+  });
+
+  // base64url-encoded 16-byte buffer from mocked `generateChallenge()`
+  expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -2,13 +2,16 @@ import type {
   PublicKeyCredentialCreationOptionsJSON,
   Base64URLString,
 } from '@simplewebauthn/typescript-types';
+import base64url from 'base64url';
+
+import generateChallenge from '../helpers/generateChallenge';
 
 type Options = {
   serviceName: string;
   rpID: string;
-  challenge: string;
   userID: string;
   userName: string;
+  challenge?: string | Buffer;
   userDisplayName?: string;
   timeout?: number;
   attestationType?: AttestationConveyancePreference;
@@ -54,9 +57,9 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
  *
  * @param serviceName Friendly user-visible website name
  * @param rpID Valid domain name (after `https://`)
- * @param challenge Random string the authenticator needs to sign and pass back
  * @param userID User's website-specific unique ID
  * @param userName User's website-specific username (email, etc...)
+ * @param challenge Random string the authenticator needs to sign and pass back
  * @param userDisplayName User's actual name
  * @param timeout How long (in ms) the user can take to complete attestation
  * @param attestationType Specific attestation statement
@@ -75,9 +78,9 @@ export default function generateAttestationOptions(
   const {
     serviceName,
     rpID,
-    challenge,
     userID,
     userName,
+    challenge = generateChallenge(),
     userDisplayName = userName,
     timeout = 60000,
     attestationType = 'none',
@@ -100,7 +103,7 @@ export default function generateAttestationOptions(
     }));
 
   return {
-    challenge,
+    challenge: base64url.encode(challenge),
     rp: {
       name: serviceName,
       id: rpID,

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -59,7 +59,7 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
  * @param rpID Valid domain name (after `https://`)
  * @param userID User's website-specific unique ID
  * @param userName User's website-specific username (email, etc...)
- * @param challenge Random string the authenticator needs to sign and pass back
+ * @param challenge Random value the authenticator needs to sign and pass back
  * @param userDisplayName User's actual name
  * @param timeout How long (in ms) the user can take to complete attestation
  * @param attestationType Specific attestation statement

--- a/packages/server/src/attestation/verifyAttestationResponse.test.ts
+++ b/packages/server/src/attestation/verifyAttestationResponse.test.ts
@@ -320,7 +320,6 @@ test('should throw an error if user verification is required but user was not ve
 
 test('should validate TPM RSA response (SHA256)', async () => {
   const expectedChallenge = '3a07cf85-e7b6-447f-8270-b25433f6018e';
-  jest.spyOn(base64url, 'encode').mockReturnValueOnce(expectedChallenge);
   const verification = await verifyAttestationResponse({
     credential: {
       id: 'lGkWHPe88VpnNYgVBxzon_MRR9-gmgODveQ16uM_bPM',
@@ -349,7 +348,6 @@ test('should validate TPM RSA response (SHA256)', async () => {
 
 test('should validate TPM RSA response (SHA1)', async () => {
   const expectedChallenge = 'f4e8d87b-d363-47cc-ab4d-1a84647bf245';
-  jest.spyOn(base64url, 'encode').mockReturnValueOnce(expectedChallenge);
   const verification = await verifyAttestationResponse({
     credential: {
       id: 'oELnad0f6-g2BtzEn_78iLNoubarlq0xFtOtAMXnflU',
@@ -378,7 +376,6 @@ test('should validate TPM RSA response (SHA1)', async () => {
 
 test('should validate Android-Key response', async () => {
   const expectedChallenge = '14e0d1b6-9c36-4849-aeec-ea64676449ef';
-  jest.spyOn(base64url, 'encode').mockReturnValueOnce(expectedChallenge);
   const verification = await verifyAttestationResponse({
     credential: {
       id: 'PPa1spYTB680cQq5q6qBtFuPLLdG1FQ73EastkT8n0o',
@@ -423,7 +420,7 @@ const attestationFIDOU2F = {
   getClientExtensionResults: () => ({}),
   type: 'public-key',
 };
-const attestationFIDOU2FChallenge = 'totallyUniqueValueEveryAttestation';
+const attestationFIDOU2FChallenge = base64url.encode('totallyUniqueValueEveryAttestation');
 
 const attestationPacked = {
   id: 'bbb',
@@ -444,7 +441,7 @@ const attestationPacked = {
   getClientExtensionResults: () => ({}),
   type: 'public-key',
 };
-const attestationPackedChallenge = 's6PIbBnPPnrGNSBxNdtDrT7UrVYJK9HM';
+const attestationPackedChallenge = base64url.encode('s6PIbBnPPnrGNSBxNdtDrT7UrVYJK9HM');
 
 const attestationPackedX5C = {
   // TODO: Grab these from another iPhone attestation
@@ -475,7 +472,7 @@ const attestationPackedX5C = {
   getClientExtensionResults: () => ({}),
   type: 'public-key',
 };
-const attestationPackedX5CChallenge = 'totallyUniqueValueEveryTime';
+const attestationPackedX5CChallenge = base64url.encode('totallyUniqueValueEveryTime');
 
 const attestationNone = {
   id: 'AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY',
@@ -494,4 +491,4 @@ const attestationNone = {
   getClientExtensionResults: () => ({}),
   type: 'public-key',
 };
-const attestationNoneChallenge = 'hEccPWuziP00H0p5gxh2_u5_PC4NeYgd';
+const attestationNoneChallenge = base64url.encode('hEccPWuziP00H0p5gxh2_u5_PC4NeYgd');

--- a/packages/server/src/attestation/verifyAttestationResponse.ts
+++ b/packages/server/src/attestation/verifyAttestationResponse.ts
@@ -30,8 +30,8 @@ type Options = {
  * **Options:**
  *
  * @param credential Authenticator credential returned by browser's `startAttestation()`
- * @param expectedChallenge The random value provided to generateAttestationOptions for the
- * authenticator to sign
+ * @param expectedChallenge The base64url-encoded `options.challenge` returned by
+ * `generateAttestationOptions()`
  * @param expectedOrigin Website URL that the attestation should have occurred on
  * @param expectedRPID RP ID that was specified in the attestation options
  * @param requireUserVerification (Optional) Enforce user verification by the authenticator
@@ -77,10 +77,9 @@ export default async function verifyAttestationResponse(
   }
 
   // Ensure the device provided the challenge we gave it
-  const encodedExpectedChallenge = base64url.encode(expectedChallenge);
-  if (challenge !== encodedExpectedChallenge) {
+  if (challenge !== expectedChallenge) {
     throw new Error(
-      `Unexpected attestation challenge "${challenge}", expected "${encodedExpectedChallenge}"`,
+      `Unexpected attestation challenge "${challenge}", expected "${expectedChallenge}"`,
     );
   }
 

--- a/packages/server/src/helpers/__mocks__/generateChallenge.ts
+++ b/packages/server/src/helpers/__mocks__/generateChallenge.ts
@@ -1,0 +1,3 @@
+export default function generateChallenge(): Buffer {
+  return Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+}

--- a/packages/server/src/helpers/generateChallenge.test.ts
+++ b/packages/server/src/helpers/generateChallenge.test.ts
@@ -1,0 +1,14 @@
+import generateChallenge from './generateChallenge';
+
+test('should return a buffer of at least 32 bytes', () => {
+  const challenge = generateChallenge();
+
+  expect(challenge.byteLength).toBeGreaterThanOrEqual(32);
+});
+
+test('should return random bytes on each execution', () => {
+  const challenge1 = generateChallenge();
+  const challenge2 = generateChallenge();
+
+  expect(challenge1).not.toEqual(challenge2);
+});

--- a/packages/server/src/helpers/generateChallenge.ts
+++ b/packages/server/src/helpers/generateChallenge.ts
@@ -1,0 +1,16 @@
+import crypto from 'crypto';
+
+/**
+ * Generate a suitably random value to be used as an attestation or assertion challenge
+ */
+export default function generateChallenge(): Buffer {
+  /**
+   * WebAuthn spec says that 16 bytes is a good minimum:
+   *
+   * "In order to prevent replay attacks, the challenges MUST contain enough entropy to make
+   * guessing them infeasible. Challenges SHOULD therefore be at least 16 bytes long."
+   *
+   * Just in case, let's double it
+   */
+  return crypto.randomBytes(32);
+}


### PR DESCRIPTION
This PR incorporates feedback in #39 to improve challenges support:

- **[server]** The `challenge` parameter of `generateAttestationOptions()` and `generateAssertionOptions()` is now _optional_.
  - **When undefined** the library will generate a random challenge. This value will be base64url-encoded in preparation for transit to the front end.
  - **When defined** the value will be directly encoded to base64url in preparation for transit to the front end.
- **[server]** `verifyAttestationResponse()` and `verifyAssertionResponse()` now require the above base64url-encoded challenge to be passed in as `expectedChallenge`.
- **[browser]** `startAttestation()` and `startAssertion()` now convert the base64url-encoded `options.challenge` to a buffer before passing it to the authenticator.