### PR TITLE
bugfix/custom-atte-option-algos

### DIFF
--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -141,7 +141,7 @@ test('should generate a challenge if one is not provided', () => {
   expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });
 
-test('should use custom supported algorithm IDs when provided', () => {
+test('should use custom supported algorithm IDs as-is when provided', () => {
   const options = generateAttestationOptions({
     rpID: 'not.real',
     serviceName: 'SimpleWebAuthn',

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -140,3 +140,19 @@ test('should generate a challenge if one is not provided', () => {
   // base64url-encoded 16-byte buffer from mocked `generateChallenge()`
   expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });
+
+test('should use custom supported algorithm IDs when provided', () => {
+  const options = generateAttestationOptions({
+    rpID: 'not.real',
+    serviceName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    supportedAlgorithmIDs: [-7, -8, -65535],
+  });
+
+  expect(options.pubKeyCredParams).toEqual([
+    { alg: -7, type: 'public-key' },
+    { alg: -8, type: 'public-key' },
+    { alg: -65535, type: 'public-key' },
+  ]);
+});

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -51,7 +51,8 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
 ];
 
 /**
- * Filter out known bad/deprecated/etc... algorithm ID's
+ * Filter out known bad/deprecated/etc... algorithm ID's so they're not used for new attestations.
+ * See https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  */
 const defaultSupportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers.filter(id => id !== -65535);
 

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -51,6 +51,11 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
 ];
 
 /**
+ * Filter out known bad/deprecated/etc... algorithm ID's
+ */
+const defaultSupportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers.filter(id => id !== -65535);
+
+/**
  * Prepare a value to pass into navigator.credentials.create(...) for authenticator "registration"
  *
  * **Options:**
@@ -88,19 +93,16 @@ export default function generateAttestationOptions(
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     authenticatorSelection,
     extensions,
-    supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers,
+    supportedAlgorithmIDs = defaultSupportedAlgorithmIDs,
   } = options;
 
   /**
-   * Filter out known bad/deprecated/etc... algorithm ID's before preparing pubKeyCredParams
-   * from the array of algorithm ID's
+   * Prepare pubKeyCredParams from the array of algorithm ID's
    */
-  const pubKeyCredParams: PublicKeyCredentialParameters[] = supportedAlgorithmIDs
-    .filter(id => id !== -65535)
-    .map(id => ({
-      alg: id,
-      type: 'public-key',
-    }));
+  const pubKeyCredParams: PublicKeyCredentialParameters[] = supportedAlgorithmIDs.map(id => ({
+    alg: id,
+    type: 'public-key',
+  }));
 
   return {
     challenge: base64url.encode(challenge),

--- a/packages/server/src/attestation/verifications/tpm/verifyTPM.ts
+++ b/packages/server/src/attestation/verifications/tpm/verifyTPM.ts
@@ -220,9 +220,9 @@ export default async function verifyTPM(options: Options): Promise<boolean> {
   let extKeyUsage: ExtendedKeyUsage | undefined;
   parsedCert.tbsCertificate.extensions.forEach(ext => {
     if (ext.extnID === id_ce_subjectAltName) {
-      subjectAltNamePresent = AsnParser.parse(ext.extnValue.slice(0), SubjectAlternativeName);
+      subjectAltNamePresent = AsnParser.parse(ext.extnValue, SubjectAlternativeName);
     } else if (ext.extnID === id_ce_extKeyUsage) {
-      extKeyUsage = AsnParser.parse(ext.extnValue.slice(0), ExtendedKeyUsage);
+      extKeyUsage = AsnParser.parse(ext.extnValue, ExtendedKeyUsage);
     }
   });
 


### PR DESCRIPTION
This PR stops filtering out known bad/deprecated algorithm ID's from custom arrays of ID's specified while generating attestation options. This is an enhancement of functionality introduced while addressing #36.

I'm also sneaking in a fix for a bizarre TPM attestation verification bug that I stumbled upon.