### PR TITLE
feature/authenticator-selection-defaults

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -23,8 +23,9 @@
     "prepublish": "npm run build"
   },
   "keywords": [
-    "webauthn",
     "typescript",
+    "webauthn",
+    "fido",
     "umd"
   ],
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,8 +26,9 @@
     "prepublish": "npm run build"
   },
   "keywords": [
-    "webauthn",
     "typescript",
+    "webauthn",
+    "fido",
     "node"
   ],
   "dependencies": {

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -47,6 +47,10 @@ test('should generate credential request options suitable for sending via JSON',
     timeout,
     attestation: attestationType,
     excludeCredentials: [],
+    authenticatorSelection: {
+      requireResidentKey: false,
+      userVerification: 'preferred',
+    },
   });
 });
 

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -51,6 +51,18 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
 ];
 
 /**
+ * Set up some default authenticator selection options as per the latest spec:
+ * https://www.w3.org/TR/webauthn-2/#dictdef-authenticatorselectioncriteria
+ *
+ * Helps with some older platforms (e.g. Android 7.0 Nougat) that may not be aware of these
+ * defaults.
+ */
+const defaultAuthenticatorSelection: AuthenticatorSelectionCriteria = {
+  requireResidentKey: false,
+  userVerification: 'preferred',
+};
+
+/**
  * Filter out known bad/deprecated/etc... algorithm ID's so they're not used for new attestations.
  * See https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  */
@@ -92,7 +104,7 @@ export default function generateAttestationOptions(
     attestationType = 'none',
     excludedCredentialIDs = [],
     suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
-    authenticatorSelection,
+    authenticatorSelection = defaultAuthenticatorSelection,
     extensions,
     supportedAlgorithmIDs = defaultSupportedAlgorithmIDs,
   } = options;

--- a/packages/typescript-types/package.json
+++ b/packages/typescript-types/package.json
@@ -20,8 +20,9 @@
     "prepublish": "npm run build"
   },
   "keywords": [
-    "webauthn",
     "typescript",
+    "webauthn",
+    "fido",
     "types"
   ],
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498"


### PR DESCRIPTION
This PR adds some default values for `authenticatorSelection` to help support older platforms that may not be aware of defaults declared within the spec.

This is to address issue #47.