### PR TITLE
feature/rename-serviceName-param

### DIFF
--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -3,7 +3,7 @@ jest.mock('../helpers/generateChallenge');
 import generateAttestationOptions from './generateAttestationOptions';
 
 test('should generate credential request options suitable for sending via JSON', () => {
-  const serviceName = 'SimpleWebAuthn';
+  const rpName = 'SimpleWebAuthn';
   const rpID = 'not.real';
   const challenge = 'totallyrandomvalue';
   const userID = '1234';
@@ -12,7 +12,7 @@ test('should generate credential request options suitable for sending via JSON',
   const attestationType = 'indirect';
 
   const options = generateAttestationOptions({
-    serviceName,
+    rpName,
     rpID,
     challenge,
     userID,
@@ -25,7 +25,7 @@ test('should generate credential request options suitable for sending via JSON',
     // Challenge, base64url-encoded
     challenge: 'dG90YWxseXJhbmRvbXZhbHVl',
     rp: {
-      name: serviceName,
+      name: rpName,
       id: rpID,
     },
     user: {
@@ -56,7 +56,7 @@ test('should generate credential request options suitable for sending via JSON',
 
 test('should map excluded credential IDs if specified', () => {
   const options = generateAttestationOptions({
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
@@ -75,7 +75,7 @@ test('should map excluded credential IDs if specified', () => {
 
 test('defaults to 60 seconds if no timeout is specified', () => {
   const options = generateAttestationOptions({
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
@@ -87,7 +87,7 @@ test('defaults to 60 seconds if no timeout is specified', () => {
 
 test('defaults to none attestation if no attestation type is specified', () => {
   const options = generateAttestationOptions({
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
@@ -99,7 +99,7 @@ test('defaults to none attestation if no attestation type is specified', () => {
 
 test('should set authenticatorSelection if specified', () => {
   const options = generateAttestationOptions({
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
@@ -120,7 +120,7 @@ test('should set authenticatorSelection if specified', () => {
 
 test('should set extensions if specified', () => {
   const options = generateAttestationOptions({
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     rpID: 'not.real',
     challenge: 'totallyrandomvalue',
     userID: '1234',
@@ -136,7 +136,7 @@ test('should set extensions if specified', () => {
 test('should generate a challenge if one is not provided', () => {
   const options = generateAttestationOptions({
     rpID: 'not.real',
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     userID: '1234',
     userName: 'usernameHere',
   });
@@ -148,7 +148,7 @@ test('should generate a challenge if one is not provided', () => {
 test('should use custom supported algorithm IDs as-is when provided', () => {
   const options = generateAttestationOptions({
     rpID: 'not.real',
-    serviceName: 'SimpleWebAuthn',
+    rpName: 'SimpleWebAuthn',
     userID: '1234',
     userName: 'usernameHere',
     supportedAlgorithmIDs: [-7, -8, -65535],

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -7,7 +7,7 @@ import base64url from 'base64url';
 import generateChallenge from '../helpers/generateChallenge';
 
 type Options = {
-  serviceName: string;
+  rpName: string;
   rpID: string;
   userID: string;
   userName: string;
@@ -73,7 +73,7 @@ const defaultSupportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers.filter(id
  *
  * **Options:**
  *
- * @param serviceName Friendly user-visible website name
+ * @param rpName User-visible, "friendly" website/service name
  * @param rpID Valid domain name (after `https://`)
  * @param userID User's website-specific unique ID
  * @param userName User's website-specific username (email, etc...)
@@ -94,7 +94,7 @@ export default function generateAttestationOptions(
   options: Options,
 ): PublicKeyCredentialCreationOptionsJSON {
   const {
-    serviceName,
+    rpName,
     rpID,
     userID,
     userName,
@@ -120,7 +120,7 @@ export default function generateAttestationOptions(
   return {
     challenge: base64url.encode(challenge),
     rp: {
-      name: serviceName,
+      name: rpName,
       id: rpID,
     },
     user: {


### PR DESCRIPTION
This PR renames the `serviceName` argument in `generateAttestationOptions()` to `rpName` as it maps to the `rp.name` property in the options. This brings this argument in line with the existing `rpID` argument that maps to `rp.id`.

Issue #45 inspired this update.

**This is a breaking change!** To upgrade, existing installations simply need to rename this argument.