### PR TITLE
feature/improve-browser-credential-selection

### DIFF
--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -43,7 +43,7 @@ export default async function startAttestation(
   const { id, rawId, response, type } = credential;
 
   // Convert values to base64 to make it easier to send back to the server
-  return {
+  const credentialJSON: AttestationCredentialJSON = {
     id,
     rawId: bufferToBase64URLString(rawId),
     response: {
@@ -52,4 +52,13 @@ export default async function startAttestation(
     },
     type,
   };
+
+  /**
+   * Include the authenticator's transports if the browser supports querying for them
+   */
+  if (typeof response.getTransports === 'function') {
+    credentialJSON.transports = response.getTransports();
+  }
+
+  return credentialJSON;
 }

--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -6,7 +6,18 @@ test('should generate credential request options suitable for sending via JSON',
   const challenge = 'totallyrandomvalue';
 
   const options = generateAssertionOptions({
-    ...goodOpts1,
+    allowCredentials: [
+      {
+        id: Buffer.from('1234', 'ascii').toString('base64'),
+        type: 'public-key',
+        transports: ['usb', 'nfc'],
+      },
+      {
+        id: Buffer.from('5678', 'ascii').toString('base64'),
+        type: 'public-key',
+        transports: ['internal'],
+      },
+    ],
     timeout: 1,
     challenge,
   });
@@ -18,12 +29,12 @@ test('should generate credential request options suitable for sending via JSON',
       {
         id: 'MTIzNA==',
         type: 'public-key',
-        transports: ['usb', 'ble', 'nfc', 'internal'],
+        transports: ['usb', 'nfc'],
       },
       {
         id: 'NTY3OA==',
         type: 'public-key',
-        transports: ['usb', 'ble', 'nfc', 'internal'],
+        transports: ['internal'],
       },
     ],
     timeout: 1,
@@ -31,20 +42,36 @@ test('should generate credential request options suitable for sending via JSON',
 });
 
 test('defaults to 60 seconds if no timeout is specified', () => {
-  const options = generateAssertionOptions(goodOpts1);
+  const options = generateAssertionOptions({
+    challenge: 'totallyrandomvalue',
+    allowCredentials: [
+      { id: Buffer.from('1234', 'ascii').toString('base64'), type: 'public-key' },
+      { id: Buffer.from('5678', 'ascii').toString('base64'), type: 'public-key' },
+    ],
+  });
 
   expect(options.timeout).toEqual(60000);
 });
 
 test('should not set userVerification if not specified', () => {
-  const options = generateAssertionOptions(goodOpts1);
+  const options = generateAssertionOptions({
+    challenge: 'totallyrandomvalue',
+    allowCredentials: [
+      { id: Buffer.from('1234', 'ascii').toString('base64'), type: 'public-key' },
+      { id: Buffer.from('5678', 'ascii').toString('base64'), type: 'public-key' },
+    ],
+  });
 
   expect(options.userVerification).toEqual(undefined);
 });
 
 test('should set userVerification if specified', () => {
   const options = generateAssertionOptions({
-    ...goodOpts1,
+    challenge: 'totallyrandomvalue',
+    allowCredentials: [
+      { id: Buffer.from('1234', 'ascii').toString('base64'), type: 'public-key' },
+      { id: Buffer.from('5678', 'ascii').toString('base64'), type: 'public-key' },
+    ],
     userVerification: 'required',
   });
 
@@ -53,7 +80,11 @@ test('should set userVerification if specified', () => {
 
 test('should set extensions if specified', () => {
   const options = generateAssertionOptions({
-    ...goodOpts1,
+    challenge: 'totallyrandomvalue',
+    allowCredentials: [
+      { id: Buffer.from('1234', 'ascii').toString('base64'), type: 'public-key' },
+      { id: Buffer.from('5678', 'ascii').toString('base64'), type: 'public-key' },
+    ],
     extensions: { appid: 'simplewebauthn' },
   });
 
@@ -63,19 +94,18 @@ test('should set extensions if specified', () => {
 });
 
 test('should generate a challenge if one is not provided', () => {
-  const opts = { ...goodOpts1 };
+  const opts = {
+    challenge: 'totallyrandomvalue',
+    allowCredentials: [
+      { id: Buffer.from('1234', 'ascii').toString('base64'), type: 'public-key' },
+      { id: Buffer.from('5678', 'ascii').toString('base64'), type: 'public-key' },
+    ],
+  };
   delete opts.challenge;
 
+  // @ts-ignore 2345
   const options = generateAssertionOptions(opts);
 
   // base64url-encoded 16-byte buffer from mocked `generateChallenge()`
   expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });
-
-const goodOpts1 = {
-  challenge: 'totallyrandomvalue',
-  allowedCredentialIDs: [
-    Buffer.from('1234', 'ascii').toString('base64'),
-    Buffer.from('5678', 'ascii').toString('base64'),
-  ],
-};

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -9,7 +9,6 @@ import generateChallenge from '../helpers/generateChallenge';
 type Options = {
   allowCredentials: PublicKeyCredentialDescriptorJSON[];
   challenge?: string | Buffer;
-  suggestedTransports?: AuthenticatorTransport[];
   timeout?: number;
   userVerification?: UserVerificationRequirement;
   extensions?: AuthenticationExtensionsClientInputs;

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -1,13 +1,13 @@
 import type {
   PublicKeyCredentialRequestOptionsJSON,
-  Base64URLString,
+  PublicKeyCredentialDescriptorJSON,
 } from '@simplewebauthn/typescript-types';
 import base64url from 'base64url';
 
 import generateChallenge from '../helpers/generateChallenge';
 
 type Options = {
-  allowedCredentialIDs: Base64URLString[];
+  allowCredentials: PublicKeyCredentialDescriptorJSON[];
   challenge?: string | Buffer;
   suggestedTransports?: AuthenticatorTransport[];
   timeout?: number;
@@ -18,11 +18,10 @@ type Options = {
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator "login"
  *
- * @param allowedCredentialIDs Array of base64url-encoded authenticator IDs registered by the
+ * @param allowCredentials Authenticators previously registered by the user
  * @param challenge Random value the authenticator needs to sign and pass back
  * user for assertion
  * @param timeout How long (in ms) the user can take to complete assertion
- * @param suggestedTransports Suggested types of authenticators for assertion
  * @param userVerification Set to `'discouraged'` when asserting as part of a 2FA flow, otherwise
  * set to `'preferred'` or `'required'` as desired.
  * @param extensions Additional plugins the authenticator or browser should use during assertion
@@ -31,9 +30,8 @@ export default function generateAssertionOptions(
   options: Options,
 ): PublicKeyCredentialRequestOptionsJSON {
   const {
-    allowedCredentialIDs,
+    allowCredentials,
     challenge = generateChallenge(),
-    suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
     timeout = 60000,
     userVerification,
     extensions,
@@ -41,11 +39,7 @@ export default function generateAssertionOptions(
 
   return {
     challenge: base64url.encode(challenge),
-    allowCredentials: allowedCredentialIDs.map(id => ({
-      id,
-      type: 'public-key',
-      transports: suggestedTransports,
-    })),
+    allowCredentials,
     timeout,
     userVerification,
     extensions,

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -61,7 +61,9 @@ test('should map excluded credential IDs if specified', () => {
     challenge: 'totallyrandomvalue',
     userID: '1234',
     userName: 'usernameHere',
-    excludedCredentialIDs: ['someIDhere'],
+    excludeCredentials: [
+      { id: 'someIDhere', type: 'public-key', transports: ['usb', 'ble', 'nfc', 'internal'] },
+    ],
   });
 
   expect(options.excludeCredentials).toEqual([

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -1,6 +1,6 @@
 import type {
   PublicKeyCredentialCreationOptionsJSON,
-  Base64URLString,
+  PublicKeyCredentialDescriptorJSON,
 } from '@simplewebauthn/typescript-types';
 import base64url from 'base64url';
 
@@ -15,8 +15,7 @@ type Options = {
   userDisplayName?: string;
   timeout?: number;
   attestationType?: AttestationConveyancePreference;
-  excludedCredentialIDs?: Base64URLString[];
-  suggestedTransports?: AuthenticatorTransport[];
+  excludeCredentials?: PublicKeyCredentialDescriptorJSON[];
   authenticatorSelection?: AuthenticatorSelectionCriteria;
   extensions?: AuthenticationExtensionsClientInputs;
   supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
@@ -81,9 +80,8 @@ const defaultSupportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers.filter(id
  * @param userDisplayName User's actual name
  * @param timeout How long (in ms) the user can take to complete attestation
  * @param attestationType Specific attestation statement
- * @param excludedCredentialIDs Array of base64url-encoded authenticator IDs registered by the
- * user so the user can't register the same credential multiple times
- * @param suggestedTransports Suggested types of authenticators for attestation
+ * @param excludeCredentials Authenticators registered by the user so the user can't register the
+ * same credential multiple times
  * @param authenticatorSelection Advanced criteria for restricting the types of authenticators that
  * may be used
  * @param extensions Additional plugins the authenticator or browser should use during attestation
@@ -102,8 +100,7 @@ export default function generateAttestationOptions(
     userDisplayName = userName,
     timeout = 60000,
     attestationType = 'none',
-    excludedCredentialIDs = [],
-    suggestedTransports = ['usb', 'ble', 'nfc', 'internal'],
+    excludeCredentials = [],
     authenticatorSelection = defaultAuthenticatorSelection,
     extensions,
     supportedAlgorithmIDs = defaultSupportedAlgorithmIDs,
@@ -131,11 +128,7 @@ export default function generateAttestationOptions(
     pubKeyCredParams,
     timeout,
     attestation: attestationType,
-    excludeCredentials: excludedCredentialIDs.map(id => ({
-      id,
-      type: 'public-key',
-      transports: suggestedTransports,
-    })),
+    excludeCredentials,
     authenticatorSelection,
     extensions,
   };

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -49,6 +49,7 @@ export interface AttestationCredentialJSON
   extends Omit<AttestationCredential, 'response' | 'rawId' | 'getClientExtensionResults'> {
   rawId: Base64URLString;
   response: AuthenticatorAttestationResponseJSON;
+  transports?: AuthenticatorTransport[];
 }
 
 /**

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -38,7 +38,7 @@ export interface PublicKeyCredentialUserEntityJSON
  * The value returned from navigator.credentials.create()
  */
 export interface AttestationCredential extends PublicKeyCredential {
-  response: AuthenticatorAttestationResponse;
+  response: AuthenticatorAttestationResponseFuture;
 }
 
 /**
@@ -73,7 +73,7 @@ export interface AssertionCredentialJSON
  * are Base64URL-encoded in the browser so that they can be sent as JSON to the server.
  */
 export interface AuthenticatorAttestationResponseJSON
-  extends Omit<AuthenticatorAttestationResponse, 'clientDataJSON' | 'attestationObject'> {
+  extends Omit<AuthenticatorAttestationResponseFuture, 'clientDataJSON' | 'attestationObject'> {
   clientDataJSON: Base64URLString;
   attestationObject: Base64URLString;
 }

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -110,8 +110,9 @@ export type AuthenticatorDevice = {
 export type Base64URLString = string;
 
 /**
- * AuthenticatorAttestationResponse in lib.dom.d.ts is outdated. Maintain an augmented version here
- * so we can implement additional properties as the WebAuthn spec evolves.
+ * AuthenticatorAttestationResponse in TypeScript's DOM lib is outdated (up through v3.9.7).
+ * Maintain an augmented version here so we can implement additional properties as the WebAuthn
+ * spec evolves.
  *
  * See https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse
  *

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -7,9 +7,8 @@
  * A variant of PublicKeyCredentialCreationOptions suitable for JSON transmission to the browser to
  * (eventually) get passed into navigator.credentials.create(...) in the browser.
  */
-export interface PublicKeyCredentialCreationOptionsJSON extends Omit<
-PublicKeyCredentialCreationOptions, 'challenge' | 'user' | 'excludeCredentials'
-> {
+export interface PublicKeyCredentialCreationOptionsJSON
+  extends Omit<PublicKeyCredentialCreationOptions, 'challenge' | 'user' | 'excludeCredentials'> {
   user: PublicKeyCredentialUserEntityJSON;
   challenge: Base64URLString;
   excludeCredentials: PublicKeyCredentialDescriptorJSON[];
@@ -19,22 +18,19 @@ PublicKeyCredentialCreationOptions, 'challenge' | 'user' | 'excludeCredentials'
  * A variant of PublicKeyCredentialRequestOptions suitable for JSON transmission to the browser to
  * (eventually) get passed into navigator.credentials.get(...) in the browser.
  */
-export interface PublicKeyCredentialRequestOptionsJSON extends Omit<
-PublicKeyCredentialRequestOptions, 'challenge' |'allowCredentials'
-> {
+export interface PublicKeyCredentialRequestOptionsJSON
+  extends Omit<PublicKeyCredentialRequestOptions, 'challenge' | 'allowCredentials'> {
   challenge: Base64URLString;
   allowCredentials: PublicKeyCredentialDescriptorJSON[];
 }
 
-export interface PublicKeyCredentialDescriptorJSON extends Omit<
-PublicKeyCredentialDescriptor, 'id'
-> {
+export interface PublicKeyCredentialDescriptorJSON
+  extends Omit<PublicKeyCredentialDescriptor, 'id'> {
   id: Base64URLString;
 }
 
-export interface PublicKeyCredentialUserEntityJSON extends Omit <
-PublicKeyCredentialUserEntity, 'id'
-> {
+export interface PublicKeyCredentialUserEntityJSON
+  extends Omit<PublicKeyCredentialUserEntity, 'id'> {
   id: Base64URLString;
 }
 
@@ -111,3 +107,18 @@ export type AuthenticatorDevice = {
  * An attempt to communicate that this isn't just any string, but a Base64URL-encoded string
  */
 export type Base64URLString = string;
+
+/**
+ * AuthenticatorAttestationResponse in lib.dom.d.ts is outdated. Maintain an augmented version here
+ * so we can implement additional properties as the WebAuthn spec evolves.
+ *
+ * See https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse
+ *
+ * Properties marked optional are not supported in all browsers.
+ */
+export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAttestationResponse {
+  getTransports?: () => AuthenticatorTransport[];
+  getAuthenticatorData?: () => ArrayBuffer;
+  getPublicKey?: () => ArrayBuffer;
+  getPublicKeyAlgorithm?: () => COSEAlgorithmIdentifier[];
+}


### PR DESCRIPTION
Issue #57 highlighted a weakness in the way `allowCredentials` is composed when generating assertion options: multiple credentials registered to a single user account would all use the same list of transports. The RP should be able to specify individual lists of transports for each authenticator as certain transports may not be suitable (i.e. `["usb", "nfc"]` would not be suitable transports for TouchID, nor would `["internal"]` be suitable for a Yubikey) .

This PR addresses this issue by removing the abstraction from the `allowCredentials` option returned by **server's** `generateAssertionOptions()`. `generateAttestationOptions()`'s `excludeCredentials` suffered from the same issue so it too is updated in this PR.

**This is a breaking change!** Here's how to upgrade existing implementations:

**generateAssertionOptions()**
```js
// OLD
const options = generateAssertionOptions({
  allowedCredentialIDs: user.devices.map(dev => dev.credentialID),
  suggestedTransports: ['usb', 'ble', 'nfc', 'internal'],
});

// NEW
const options = generateAssertionOptions({
  allowCredentials: devices.map(dev => ({
    id: dev.credentialID,
    type: 'public-key',
    transports: dev.transports,
  })),
});
```

**generateAttestationOptions()**
```js
// OLD
const options = generateAttestationOptions({
  excludedCredentialIDs: devices.map(dev => dev.credentialID),
  suggestedTransports: ['usb', 'ble', 'nfc', 'internal'],
});

// NEW
const options = generateAttestationOptions({
  excludeCredentials: devices.map(dev => ({
    id: dev.credentialID,
    type: 'public-key',
    transports: dev.transports,
  })),
});
```

As an added bonus, the credential returned by **browser's** `startAttestation()` method will now include the value of `response.getTransports()` (where supported) so that the RP can store an authenticator's specific list of transports. This list of transports, available on the new `transports` property, can then be used in `generateAttestationOptions()` and `generateAssertionOptions()` to help the RP better control authenticator registration and verification.