### PR TITLE
fix/server-pin-dependencies

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,17 +32,17 @@
     "node"
   ],
   "dependencies": {
-    "@peculiar/asn1-android": "^2.0.8",
-    "@peculiar/asn1-schema": "^2.0.8",
-    "@peculiar/asn1-x509": "^2.0.10",
+    "@peculiar/asn1-android": "2.0.8",
+    "@peculiar/asn1-schema": "2.0.8",
+    "@peculiar/asn1-x509": "2.0.10",
     "@simplewebauthn/typescript-types": "file:../typescript-types",
-    "base64url": "^3.0.1",
-    "cbor": "^5.0.2",
-    "elliptic": "^6.5.3",
-    "jsrsasign": "^8.0.20",
-    "jwk-to-pem": "^2.0.4",
-    "node-fetch": "^2.6.0",
-    "node-rsa": "^1.1.1"
+    "base64url": "3.0.1",
+    "cbor": "5.0.2",
+    "elliptic": "6.5.3",
+    "jsrsasign": "8.0.20",
+    "jwk-to-pem": "2.0.4",
+    "node-fetch": "2.6.0",
+    "node-rsa": "1.1.1"
   },
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498",
   "devDependencies": {


### PR DESCRIPTION
I'm more aggressively pinning **server** package dependencies to exact versions because I have observed some third-party dependencies publishing minor or revision releases that actually break this package.

For example, `"@peculiar/asn1-schema": "^2.0.8"` led to `@peculiar/asn1-schema@2.0.23` being installed. Unfortunately v2.0.23 made changes to its `OctetString` class so it'd work better in ES5 code bases, which broke the `verifyAndroidKey()` and `verifyApple()` attestation methods.

I tried a plain `npm upgrade` before resorting to this but observed new versions of `jsrsasign` and/or `cbor` breaking FIDO conformance testing with ambiguous error messages that I don't have time right now to debug. The simple solution in the short term is to simply pin these packages to exact versions for more reliable installation via npm.