### PR TITLE
feature/upgrade-asn1-libs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.1",
+  "version": "0.10.2-alpha.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -5,45 +5,45 @@
   "requires": true,
   "dependencies": {
     "@peculiar/asn1-android": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.0.8.tgz",
-      "integrity": "sha512-ebJaC1q17Psxn4u6fDD67Obr/lHmM5q50s5n8y9Joae4jx5HBS4thtzUzdmT2Rbj780NtSU4lJodweEgkXtXMQ==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.0.23.tgz",
+      "integrity": "sha512-9kNdp67kImBqR6qttUZqFahUMyu44hTYOi+E6nN+BFfwKscW3sEwcPVWdS2uclvuOgV0FAflvqxPIooLACpDwA==",
       "requires": {
-        "@peculiar/asn1-schema": "^2.0.8",
+        "@peculiar/asn1-schema": "^2.0.23",
         "asn1js": "^2.0.26",
-        "tslib": "^1.11.1"
+        "tslib": "^2.0.2"
       }
     },
     "@peculiar/asn1-schema": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.8.tgz",
-      "integrity": "sha512-D8ZqT61DdzuXfrILNvtdf7MUcTY2o9WHwmF0WgTKPEGNY5SDxNAjBY3enuwV9SXcSuCAwWac9c9v0vsswB1NIw==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.23.tgz",
+      "integrity": "sha512-dV1xQJiWTzwyjfAbvwTT+RTrS4UN9kPJuy92B6oGv572wPZxaoA8R+nxLX92jLz23L43CnLvxiBo+Rip59SWfw==",
       "requires": {
-        "@types/asn1js": "^0.0.1",
+        "@types/asn1js": "^0.0.2",
         "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1"
+        "pvtsutils": "^1.0.14",
+        "tslib": "^2.0.2"
       }
     },
     "@peculiar/asn1-x509": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.0.10.tgz",
-      "integrity": "sha512-Z0UJcAf5q3hHtvQl2EblaszMirsRHzJPEfwWkQ8g6QhSbD5nSyCnG3Z8Mn9UFqsDpzsITYtHGx7+taYrNpMHCA==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.0.23.tgz",
+      "integrity": "sha512-9tpiZirrWleYDhYT6MvDeQUWzvxz+oj8DzhQgcpY7Mq+5iPUv/+HS0NqPB7tPZOSmEHTKFisjO+YQrKefkO0qA==",
       "requires": {
-        "@peculiar/asn1-schema": "^2.0.8",
+        "@peculiar/asn1-schema": "^2.0.23",
         "asn1js": "^2.0.26",
-        "ipaddr.js": "^1.9.1",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1"
+        "ipaddr.js": "^2.0.0",
+        "pvtsutils": "^1.0.14",
+        "tslib": "^2.0.2"
       }
     },
     "@simplewebauthn/typescript-types": {
       "version": "file:../typescript-types"
     },
     "@types/asn1js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.1.tgz",
-      "integrity": "sha1-74uflwjLFjKhw6nNJ3F8qr55O8I=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.2.tgz",
+      "integrity": "sha512-xtLPq140WhPqvDZDpY70rTx4qTezHs+8htbhWQGuevBRQko8FRjFSO5WVTwXOwd3W5tQRxJ7eni30fDUP2q4wQ==",
       "requires": {
         "@types/pvutils": "*"
       }
@@ -244,9 +244,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+      "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w=="
     },
     "jsrsasign": {
       "version": "8.0.20",
@@ -288,11 +288,6 @@
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "node-rsa": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
@@ -307,11 +302,11 @@
       "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
     },
     "pvtsutils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
-      "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.14.tgz",
+      "integrity": "sha512-X9SBWQ9ceNAEEgLweoE7m7P6LDnZ3pZADBq7utQQV4pQ1vj7uQIAXaAQRCz/4nKLKQRT9ZrHOuxailKqBiztrg==",
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.0.1"
       }
     },
     "pvutils": {
@@ -330,9 +325,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     }
   }
 }

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplewebauthn/server",
-  "version": "0.10.1",
+  "version": "0.10.2-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplewebauthn/server",
-  "version": "0.10.1",
+  "version": "0.10.2-alpha.0",
   "description": "SimpleWebAuthn for Servers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,9 +32,9 @@
     "node"
   ],
   "dependencies": {
-    "@peculiar/asn1-android": "2.0.8",
-    "@peculiar/asn1-schema": "2.0.8",
-    "@peculiar/asn1-x509": "2.0.10",
+    "@peculiar/asn1-android": "2.0.23",
+    "@peculiar/asn1-schema": "2.0.23",
+    "@peculiar/asn1-x509": "2.0.23",
     "@simplewebauthn/typescript-types": "file:../typescript-types",
     "base64url": "3.0.1",
     "cbor": "5.0.2",

--- a/packages/server/src/attestation/verifications/verifyAndroidKey.ts
+++ b/packages/server/src/attestation/verifications/verifyAndroidKey.ts
@@ -61,7 +61,7 @@ export default async function verifyAttestationAndroidKey(options: Options): Pro
   // Verify extKeyStore values
   const { attestationChallenge, teeEnforced, softwareEnforced } = parsedExtKeyStore;
 
-  if (!Buffer.from(attestationChallenge).equals(clientDataHash)) {
+  if (!Buffer.from(attestationChallenge.buffer).equals(clientDataHash)) {
     throw new Error('Attestation challenge was not equal to client data hash (AndroidKey)');
   }
 

--- a/packages/server/src/attestation/verifications/verifyApple.ts
+++ b/packages/server/src/attestation/verifications/verifyApple.ts
@@ -59,7 +59,7 @@ export default async function verifyApple(options: Options): Promise<boolean> {
    * TODO: Try and get @peculiar (GitHub) to add a schema for "1.2.840.113635.100.8.2" when we
    * find out where it's defined (doesn't seem to be publicly documented at the moment...)
    */
-  const extNonce = Buffer.from(extCertNonce.extnValue).slice(6);
+  const extNonce = Buffer.from(extCertNonce.extnValue.buffer).slice(6);
 
   if (!nonce.equals(extNonce)) {
     throw new Error(`credCert nonce was not expected value (Apple)`);


### PR DESCRIPTION
This PR updates the `@peculiar/asn1-*` libraries to their latest version v2.0.23. This should help fix part of #61 by making **server** compatible with these latest releases that are getting pulled in anyway as sub-dependencies.