### PR TITLE
feature/assertion-rp-id

### DIFF
--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -109,3 +109,15 @@ test('should generate a challenge if one is not provided', () => {
   // base64url-encoded 16-byte buffer from mocked `generateChallenge()`
   expect(options.challenge).toEqual('AQIDBAUGBwgJCgsMDQ4PEA');
 });
+
+test('should set rpId if specified', () => {
+  const rpID = 'simplewebauthn.dev';
+
+  const opts = generateAssertionOptions({
+    allowCredentials: [],
+    rpID,
+  });
+
+  expect(opts.rpId).toBeDefined();
+  expect(opts.rpId).toEqual(rpID);
+});

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -12,6 +12,7 @@ type Options = {
   timeout?: number;
   userVerification?: UserVerificationRequirement;
   extensions?: AuthenticationExtensionsClientInputs;
+  rpID?: string;
 };
 
 /**
@@ -24,6 +25,7 @@ type Options = {
  * @param userVerification Set to `'discouraged'` when asserting as part of a 2FA flow, otherwise
  * set to `'preferred'` or `'required'` as desired.
  * @param extensions Additional plugins the authenticator or browser should use during assertion
+ * @param rpID Valid domain name (after `https://`)
  */
 export default function generateAssertionOptions(
   options: Options,
@@ -34,6 +36,7 @@ export default function generateAssertionOptions(
     timeout = 60000,
     userVerification,
     extensions,
+    rpID,
   } = options;
 
   return {
@@ -42,5 +45,6 @@ export default function generateAssertionOptions(
     timeout,
     userVerification,
     extensions,
+    rpId: rpID,
   };
 }


### PR DESCRIPTION
This PR adds a new `rpID` argument to server's `generateAssertionOptions()`. This string argument is mapped to [the `rpId` value in `PublicKeyCredentialRequestOptions`](https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options).

Issue #63 should be resolved by this PR.

I went with "rpID" here so that it mirrors the same argument in `generateAttestationOptions()`. This will hopefully help communicate the fact that the same value passed into `generateAttestationOptions()` can be specified here as well.