### PR TITLE
bugfix/fix-docs-netlify-deploy

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
   },
   "exclude": [
     "node_modules",
+    "example",
     "**/*.test.ts",
     "**/setupTests.ts",
     "**/__mocks__/*",

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -6,6 +6,9 @@
       "@simplewebauthn/*": ["packages/*/src"]
     }
   },
+  "exclude": [
+    "example"
+  ],
   "typedocOptions": {
     "out": "docs",
     "entryPoints": [

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -6,9 +6,6 @@
       "@simplewebauthn/*": ["packages/*/src"]
     }
   },
-  "exclude": [
-    "example"
-  ],
   "typedocOptions": {
     "out": "docs",
     "entryPoints": [


### PR DESCRIPTION
This PR tells monorepo TypeScript to ignore the **example/** directory. It should exist as a standalone TypeScript project with no impact on anything outside of itself.

For additional context: it seems converting the Example Project to TypeScript had TypeDoc trying to crawl it as part of docs generation. When dependencies weren't installed in the **example/** directory, the example project would complain about missing dependencies and error out the whole thing. By ignoring the folder TypeDoc is able to generate docs as before.