### PR TITLE
feat/testing-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "simplewebauthn-monorepo",
   "private": true,
   "scripts": {
-    "bootstrap": "npm run build:types && npm run build:browser && npm run build:server",
+    "bootstrap": "npm run build:types && npm run build:testing && npm run build:browser && npm run build:server",
     "lint": "prettier --write packages/ example/ && eslint --fix packages/ example/",
     "docs": "npm run bootstrap && typedoc --tsconfig tsconfigdoc.json",
     "test": "lerna run test",
     "build:types": "lerna bootstrap --scope=@simplewebauthn/typescript-types",
+    "build:testing": "lerna bootstrap --scope=@simplewebauthn/testing",
     "build:browser": "lerna bootstrap --scope=@simplewebauthn/browser",
     "build:server": "lerna bootstrap --scope=@simplewebauthn/server",
     "dev:server": "lerna exec npm run test:watch --scope=@simplewebauthn/server",

--- a/packages/testing/.npmignore
+++ b/packages/testing/.npmignore
@@ -1,0 +1,7 @@
+src
+node_modules
+coverage
+.gitignore
+tsconfig.json
+*.config.js
+__mocks__

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,6 @@
+# @simplewebauthn/testing
+
+![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
+[![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/testing?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/testing)
+
+Sample WebAuthn credentials and other such values that can be used to test projects leveraging SimpleWebAuthn.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@simplewebauthn/testing",
+  "version": "0.10.5",
+  "description": "Sample WebAuthn values for testing projects leveraging SimpleWebAuthn.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Matthew Miller <matthew@millerti.me>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MasterKale/SimpleWebAuthn.git",
+    "directory": "packages/testing"
+  },
+  "homepage": "https://github.com/MasterKale/SimpleWebAuthn/tree/master/packages/testing#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rimraf dist && tsc",
+    "prepublish": "npm run build"
+  },
+  "keywords": [
+    "typescript",
+    "webauthn",
+    "fido",
+    "types"
+  ]
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @packageDocumentation
+ * @module @simplewebauthn/testing
+ */

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This PR is in response to a request in #82. This adds a new "testing" package to the project.

Going forward the plan is to relocate many of the credentials that are scattered throughout the various unit tests in the **server** and **browser** packages into **testing**. They'll eventually get combined with various configurations of attestation and assertion options so that projects implementing SimpleWebAuthn can import these values from **testing** to use in their own unit and integration tests.

Migrating values into **testing** won't happen overnight. This will be a gradual migration as future work is completed on this project.