### PR TITLE
Lazy Text Encoder

### DIFF
--- a/packages/browser/src/helpers/toUint8Array.ts
+++ b/packages/browser/src/helpers/toUint8Array.ts
@@ -1,9 +1,7 @@
-const utf8Encoder = new TextEncoder();
-
 /**
  * A helper method to convert an arbitrary string sent from the server to a Uint8Array the
  * authenticator will expect.
  */
 export default function toUint8Array(value: string): Uint8Array {
-  return utf8Encoder.encode(value);
+  return new TextEncoder().encode(value);
 }


### PR DESCRIPTION
Found an issue during some JSDOM Jest tests.

TextEncoder is not currently supported correctly into `jsdom` env of Jest.

To avoid a systemic crash at import time it's better to init text encoder into the function.

A workaround is to use the `node` env of Jest. But some tests require jsdom and could import indirectly the package.
