### PR TITLE
feat/W3C-L2-update

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -21,6 +21,10 @@ import {
   generateAssertionOptions,
   verifyAssertionResponse,
 } from '@simplewebauthn/server';
+import type {
+  AttestationCredentialJSON,
+  AuthenticatorDevice,
+} from '@simplewebauthn/typescript-types';
 
 import { LoggedInUser } from './example-server';
 
@@ -65,15 +69,7 @@ const inMemoryUserDeviceDB: { [loggedInUserId: string]: LoggedInUser } = {
   [loggedInUserId]: {
     id: loggedInUserId,
     username: `user@${rpID}`,
-    devices: [
-      /**
-       * {
-       *   credentialID: string,
-       *   publicKey: string,
-       *   counter: number,
-       * }
-       */
-    ],
+    devices: [],
     /**
      * A simple way of storing a user's current challenge being signed by attestation or assertion.
      * It should be expired after `timeout` milliseconds (optional argument for `generate` methods,
@@ -135,7 +131,7 @@ app.get('/generate-attestation-options', (req, res) => {
 });
 
 app.post('/verify-attestation', async (req, res) => {
-  const { body } = req;
+  const body: AttestationCredentialJSON = req.body;
 
   const user = inMemoryUserDeviceDB[loggedInUserId];
 
@@ -165,11 +161,12 @@ app.post('/verify-attestation', async (req, res) => {
       /**
        * Add the returned device to the user's list of devices
        */
-      user.devices.push({
+      const newDevice: AuthenticatorDevice = {
         publicKey: base64PublicKey,
         credentialID: base64CredentialID,
         counter,
-      });
+      };
+      user.devices.push(newDevice);
     }
   }
 

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -119,6 +119,18 @@ export default function generateAttestationOptions(
     type: 'public-key',
   }));
 
+  /**
+   * "Relying Parties SHOULD set [requireResidentKey] to true if, and only if, residentKey is set
+   * to "required""
+   *
+   * See https://www.w3.org/TR/webauthn-2/#dom-authenticatorselectioncriteria-requireresidentkey
+   */
+  if (authenticatorSelection.residentKey === 'required') {
+    authenticatorSelection.requireResidentKey = true;
+  } else {
+    authenticatorSelection.requireResidentKey = false;
+  }
+
   return {
     challenge: base64url.encode(challenge),
     rp: {

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -116,6 +116,8 @@ export type AuthenticatorDevice = {
   credentialID: Base64URLString;
   // Number of times this device is expected to have been used
   counter: number;
+  // From browser's `startAttestation()` -> AttestationCredentialJSON.transports (API L2 and up)
+  transports?: AuthenticatorTransport[];
 };
 
 /**


### PR DESCRIPTION
This PR contains library tweaks in preparation for L2 of the WebAuthn spec (now a Candidate Recommendation) becoming the next Recommendation (optimistically sometime in January). As SimpleWebAuthn implemented L2 of the spec, changes should be minimal.

As mentioned in #88, a diff of the changes between L1 and L2 can be viewed here: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2F2019%2FREC-webauthn-1-20190304%2F&doc2=https%3A%2F%2Fwww.w3.org%2FTR%2Fwebauthn-2%2F#sctn-storeCredential