### PR TITLE
fix: public key conversion

### DIFF
--- a/packages/server/src/helpers/convertPublicKeyToPEM.ts
+++ b/packages/server/src/helpers/convertPublicKeyToPEM.ts
@@ -6,7 +6,8 @@ import { COSEKEYS, COSEKTY, COSECRV } from './convertCOSEtoPKCS';
 export default function convertPublicKeyToPEM(publicKey: Buffer): string {
   let struct;
   try {
-    struct = cbor.decodeAllSync(publicKey)[0];
+    const pkBuffer = Buffer.from(publicKey);
+    struct = cbor.decodeAllSync(pkBuffer)[0];
   } catch (err) {
     throw new Error(`Error decoding public key while converting to PEM: ${err.message}`);
   }


### PR DESCRIPTION
This PR fixes an issue occuring when validating assertion. When the process enters `convertPublicKeyToPEM()`, the following error is thrown:

```
TypeError: Cannot read property 'get' of undefined
  at Object.convertPublicKeyToPEM [as default] (/home/<user>/Desktop/<my_project>/node_modules/@simplewebauthn/server/dist/helpers/convertPublicKeyToPEM.js:18:24)
  at Object.verifyAssertionResponse (/home/<user>/Desktop/<my_project>/node_modules/@simplewebauthn/server/dist/assertion/verifyAssertionResponse.js:128:54)
```

I believe this is caused because commit `548aa64bbbcfc70491a7ce2b103f9bd78ac010b6` changes the function to accept `Buffer`, instead of `string`, but the argument `publicKey` is being sent as a Buffer object and not a Buffer, resulting in the error above