### PR TITLE
fix/simplify-encoding-user-handle-in-assertion-response

### DIFF
--- a/packages/browser/jest-environment.js
+++ b/packages/browser/jest-environment.js
@@ -16,6 +16,14 @@ class CustomTestEnvironment extends Environment {
       const { TextEncoder } = require('util');
       this.global.TextEncoder = TextEncoder;
     }
+
+    /**
+     * Add support for TextDecoder to JSDOM
+     */
+    if (typeof this.global.TextDecoder === 'undefined') {
+      const { TextDecoder } = require('util');
+      this.global.TextDecoder = TextDecoder;
+    }
   }
 }
 

--- a/packages/browser/src/helpers/bufferToUTF8String.ts
+++ b/packages/browser/src/helpers/bufferToUTF8String.ts
@@ -1,0 +1,7 @@
+/**
+ * A helper method to convert an arbitrary ArrayBuffer, returned from an authenticator, to a UTF-8
+ * string.
+ */
+export default function bufferToUTF8String(value: ArrayBuffer): string {
+  return new TextDecoder('utf-8').decode(value);
+}

--- a/packages/browser/src/helpers/stringToArrayBuffer.ts
+++ b/packages/browser/src/helpers/stringToArrayBuffer.ts
@@ -2,6 +2,6 @@
  * A helper method to convert an arbitrary string sent from the server to a Uint8Array the
  * authenticator will expect.
  */
-export default function toUint8Array(value: string): Uint8Array {
+export default function stringToArrayBuffer(value: string): ArrayBuffer {
   return new TextEncoder().encode(value);
 }

--- a/packages/browser/src/helpers/stringToArrayBuffer.ts
+++ b/packages/browser/src/helpers/stringToArrayBuffer.ts
@@ -1,7 +1,0 @@
-/**
- * A helper method to convert an arbitrary string sent from the server to a Uint8Array the
- * authenticator will expect.
- */
-export default function stringToArrayBuffer(value: string): ArrayBuffer {
-  return new TextEncoder().encode(value);
-}

--- a/packages/browser/src/helpers/utf8StringToBuffer.ts
+++ b/packages/browser/src/helpers/utf8StringToBuffer.ts
@@ -1,0 +1,7 @@
+/**
+ * A helper method to convert an arbitrary string sent from the server to an ArrayBuffer the
+ * authenticator will expect.
+ */
+export default function utf8StringToBuffer(value: string): ArrayBuffer {
+  return new TextEncoder().encode(value);
+}

--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@simplewebauthn/typescript-types';
 
 import supportsWebauthn from '../helpers/supportsWebauthn';
-import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
+import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
 import startAssertion from './startAssertion';
@@ -23,7 +23,7 @@ const mockUserHandle = 'mockUserHandle';
 
 // With ASCII challenge
 const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
+  challenge: bufferToBase64URLString(utf8StringToBuffer('fizz')),
   allowCredentials: [
     {
       id: 'C0VGlvYFratUdAV1iCw-ULpUW8E-exHPXQChBfyVeJZCMfjMFcwDmOFgoMUz39LoMtCJUBW8WPlLkGT6q8qTCg',
@@ -36,7 +36,7 @@ const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
 
 // With UTF-8 challenge
 const goodOpts2UTF8: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: bufferToBase64URLString(stringToArrayBuffer('やれやれだぜ')),
+  challenge: bufferToBase64URLString(utf8StringToBuffer('やれやれだぜ')),
   allowCredentials: [],
   timeout: 1,
 };
@@ -78,7 +78,7 @@ test('should convert options before passing to navigator.credentials.get(...)', 
 
 test('should support optional allowCredential', async () => {
   await startAssertion({
-    challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
+    challenge: bufferToBase64URLString(utf8StringToBuffer('fizz')),
     timeout: 1,
   });
 
@@ -87,7 +87,7 @@ test('should support optional allowCredential', async () => {
 
 test('should convert allow allowCredential to undefined when empty', async () => {
   await startAssertion({
-    challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
+    challenge: bufferToBase64URLString(utf8StringToBuffer('fizz')),
     timeout: 1,
     allowCredentials: [],
   });

--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -120,7 +120,7 @@ test('should return base64url-encoded response values', async done => {
   expect(response.response.authenticatorData).toEqual('bW9ja0F1dGhlbnRpY2F0b3JEYXRh');
   expect(response.response.clientDataJSON).toEqual('bW9ja0NsaWVudERhdGFKU09O');
   expect(response.response.signature).toEqual('bW9ja1NpZ25hdHVyZQ');
-  expect(response.response.userHandle).toEqual('bW9ja1VzZXJIYW5kbGU');
+  expect(response.response.userHandle).toEqual('mockUserHandle');
 
   done();
 });

--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@simplewebauthn/typescript-types';
 
 import supportsWebauthn from '../helpers/supportsWebauthn';
-import toUint8Array from '../helpers/toUint8Array';
+import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
 import startAssertion from './startAssertion';
@@ -23,7 +23,7 @@ const mockUserHandle = 'mockUserHandle';
 
 // With ASCII challenge
 const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: bufferToBase64URLString(toUint8Array('fizz')),
+  challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
   allowCredentials: [
     {
       id: 'C0VGlvYFratUdAV1iCw-ULpUW8E-exHPXQChBfyVeJZCMfjMFcwDmOFgoMUz39LoMtCJUBW8WPlLkGT6q8qTCg',
@@ -36,7 +36,7 @@ const goodOpts1: PublicKeyCredentialRequestOptionsJSON = {
 
 // With UTF-8 challenge
 const goodOpts2UTF8: PublicKeyCredentialRequestOptionsJSON = {
-  challenge: bufferToBase64URLString(toUint8Array('やれやれだぜ')),
+  challenge: bufferToBase64URLString(stringToArrayBuffer('やれやれだぜ')),
   allowCredentials: [],
   timeout: 1,
 };
@@ -78,7 +78,7 @@ test('should convert options before passing to navigator.credentials.get(...)', 
 
 test('should support optional allowCredential', async () => {
   await startAssertion({
-    challenge: bufferToBase64URLString(toUint8Array('fizz')),
+    challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
     timeout: 1,
   });
 
@@ -87,7 +87,7 @@ test('should support optional allowCredential', async () => {
 
 test('should convert allow allowCredential to undefined when empty', async () => {
   await startAssertion({
-    challenge: bufferToBase64URLString(toUint8Array('fizz')),
+    challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
     timeout: 1,
     allowCredentials: [],
   });

--- a/packages/browser/src/methods/startAssertion.ts
+++ b/packages/browser/src/methods/startAssertion.ts
@@ -6,6 +6,7 @@ import {
 
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
+import bufferToUTF8String from '../helpers/bufferToUTF8String';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
@@ -46,7 +47,7 @@ export default async function startAssertion(
 
   let userHandle = undefined;
   if (response.userHandle) {
-    userHandle = bufferToBase64URLString(response.userHandle);
+    userHandle = bufferToUTF8String(response.userHandle);
   }
 
   // Convert values to base64 to make it easier to send back to the server

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -5,7 +5,7 @@ import {
   PublicKeyCredentialCreationOptionsJSON,
 } from '@simplewebauthn/typescript-types';
 
-import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
+import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
@@ -20,7 +20,7 @@ const mockAttestationObject = 'mockAtte';
 const mockClientDataJSON = 'mockClie';
 
 const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
-  challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
+  challenge: bufferToBase64URLString(utf8StringToBuffer('fizz')),
   attestation: 'direct',
   pubKeyCredParams: [
     {
@@ -90,7 +90,7 @@ test('should return base64url-encoded response values', async done => {
       return new Promise(resolve => {
         resolve({
           id: 'foobar',
-          rawId: stringToArrayBuffer('foobar'),
+          rawId: utf8StringToBuffer('foobar'),
           response: {
             attestationObject: Buffer.from(mockAttestationObject, 'ascii'),
             clientDataJSON: Buffer.from(mockClientDataJSON, 'ascii'),

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -5,7 +5,7 @@ import {
   PublicKeyCredentialCreationOptionsJSON,
 } from '@simplewebauthn/typescript-types';
 
-import toUint8Array from '../helpers/toUint8Array';
+import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 
@@ -20,7 +20,7 @@ const mockAttestationObject = 'mockAtte';
 const mockClientDataJSON = 'mockClie';
 
 const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
-  challenge: bufferToBase64URLString(toUint8Array('fizz')),
+  challenge: bufferToBase64URLString(stringToArrayBuffer('fizz')),
   attestation: 'direct',
   pubKeyCredParams: [
     {
@@ -90,7 +90,7 @@ test('should return base64url-encoded response values', async done => {
       return new Promise(resolve => {
         resolve({
           id: 'foobar',
-          rawId: toUint8Array('foobar'),
+          rawId: stringToArrayBuffer('foobar'),
           response: {
             attestationObject: Buffer.from(mockAttestationObject, 'ascii'),
             clientDataJSON: Buffer.from(mockClientDataJSON, 'ascii'),

--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -4,7 +4,7 @@ import {
   AttestationCredentialJSON,
 } from '@simplewebauthn/typescript-types';
 
-import toUint8Array from '../helpers/toUint8Array';
+import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
@@ -28,7 +28,7 @@ export default async function startAttestation(
     challenge: base64URLStringToBuffer(creationOptionsJSON.challenge),
     user: {
       ...creationOptionsJSON.user,
-      id: toUint8Array(creationOptionsJSON.user.id),
+      id: stringToArrayBuffer(creationOptionsJSON.user.id),
     },
     excludeCredentials: creationOptionsJSON.excludeCredentials.map(toPublicKeyCredentialDescriptor),
   };

--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -4,7 +4,7 @@ import {
   AttestationCredentialJSON,
 } from '@simplewebauthn/typescript-types';
 
-import stringToArrayBuffer from '../helpers/stringToArrayBuffer';
+import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import supportsWebauthn from '../helpers/supportsWebauthn';
@@ -28,7 +28,7 @@ export default async function startAttestation(
     challenge: base64URLStringToBuffer(creationOptionsJSON.challenge),
     user: {
       ...creationOptionsJSON.user,
-      id: stringToArrayBuffer(creationOptionsJSON.user.id),
+      id: utf8StringToBuffer(creationOptionsJSON.user.id),
     },
     excludeCredentials: creationOptionsJSON.excludeCredentials.map(toPublicKeyCredentialDescriptor),
   };

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -49,7 +49,7 @@ export interface PublicKeyCredentialDescriptorJSON
 
 export interface PublicKeyCredentialUserEntityJSON
   extends Omit<PublicKeyCredentialUserEntity, 'id'> {
-  id: Base64URLString;
+  id: string;
 }
 
 /**
@@ -111,7 +111,7 @@ export interface AuthenticatorAssertionResponseJSON
   authenticatorData: Base64URLString;
   clientDataJSON: Base64URLString;
   signature: Base64URLString;
-  userHandle?: Base64URLString;
+  userHandle?: string;
 }
 
 /**


### PR DESCRIPTION
While dogfooding my own library it confused me why I'd pass in `'5c240dc4-bfdf-474b-929c-c4484008a302'` as `user.id` in attestation options, but get back `'NWMyNDBkYzQtYmZkZi00NzRiLTkyOWMtYzQ0ODQwMDhhMzAy'` as `userHandle` in the assertion.

I realized that `userHandle`, returned in an assertion response, is Base64URL-encoded before coming out of `startAssertion()` for transmission back to the RP. It doesn't make any sense to do this, though, as the value is never Base64URL-encoded coming out of `generateAttestationOptions()` or within `startAttestation()`. This PR fixes this behavior so that the value of `userHandle` in an assertion response is the same as the value of `user.id` passed into `navigator.credentials.create()`.