### PR TITLE
feat/browser-bundle-version-injection

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -38,7 +38,7 @@
     "@simplewebauthn/typescript-types": "file:../typescript-types",
     "rollup": "^2.44.0",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-version-injector": "^1.3.2",
+    "rollup-plugin-version-injector": "^1.3.3",
     "tslib": "^2.2.0"
   },
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498"

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from '@rollup/plugin-typescript';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
-// import versionInjector from 'rollup-plugin-version-injector';
+import versionInjector from 'rollup-plugin-version-injector';
 
 /**
  * Rollup plugin to clean `tslib` comment in `UMD` bundle targeting `ES5`
@@ -30,23 +30,14 @@ const cleanTslibCommentInUMDBundleTargetingES5 = () => {
   };
 };
 
-/**
- * Re-enable version injection when this gets resolved:
- *
- * https://github.com/djhouseknecht/rollup-plugin-version-injector/issues/22
- *
- * To avoid a repeat of the first half of this:
- *
- * https://github.com/MasterKale/SimpleWebAuthn/issues/56
- */
-// const swanVersionInjector = versionInjector({
-//   injectInComments: {
-//     fileRegexp: /\.(js)$/,
-//     // [@simplewebauthn/browser]  Version: 2.1.0 - Saturday, February 6th, 2021, 4:10:31 PM
-//     tag: '[@simplewebauthn/browser]  Version: {version} - {date}',
-//     dateFormat: 'dddd, mmmm dS, yyyy, h:MM:ss TT',
-//   },
-// });
+const swanVersionInjector = versionInjector({
+  injectInComments: {
+    fileRegexp: /\.(js)$/,
+    // [@simplewebauthn/browser]  Version: 2.1.0 - Saturday, February 6th, 2021, 4:10:31 PM
+    tag: '[@simplewebauthn/browser]  Version: {version} - {date}',
+    dateFormat: 'dddd, mmmm dS, yyyy, h:MM:ss TT',
+  },
+});
 
 /**
  * Rollup configuration to generate the following:
@@ -72,11 +63,7 @@ export default [
         plugins: [terser()],
       },
     ],
-    plugins: [
-      typescript({ tsconfig: './tsconfig.json' }),
-      nodeResolve(),
-      // swanVersionInjector,
-    ],
+    plugins: [typescript({ tsconfig: './tsconfig.json' }), nodeResolve(), swanVersionInjector],
   },
   {
     input: 'src/index.ts',
@@ -86,11 +73,7 @@ export default [
       entryFileNames: 'es5/[name].js',
       exports: 'auto',
     },
-    plugins: [
-      typescript({ tsconfig: './tsconfig.es5.json' }),
-      nodeResolve(),
-      // swanVersionInjector,
-    ],
+    plugins: [typescript({ tsconfig: './tsconfig.es5.json' }), nodeResolve(), swanVersionInjector],
     external: ['tslib'],
   },
   {
@@ -102,10 +85,6 @@ export default [
       entryFileNames: 'es5/[name].umd.min.js',
       plugins: [terser(), cleanTslibCommentInUMDBundleTargetingES5()],
     },
-    plugins: [
-      typescript({ tsconfig: './tsconfig.es5.json' }),
-      nodeResolve(),
-      // swanVersionInjector,
-    ],
+    plugins: [typescript({ tsconfig: './tsconfig.es5.json' }), nodeResolve(), swanVersionInjector],
   },
 ];


### PR DESCRIPTION
`rollup-plugin-version-injector@1.3.3` dropped which switched to multiline comments for JS files. Multiline comments were needed to ensure that aggressive minification in consuming projects didn't break SimpleWebAuthn functionality by putting everything, including a single-line build version comment, on a single line 😱 

BTW this was the final piece of the build process that needed to be ported over to the Rollup build setup. So long, webpack, and thanks for all the builds 🐟 