### PR TITLE
refactor: parameterize apple root certificate

### DIFF
--- a/packages/server/src/attestation/verifyAttestationResponse.test.ts
+++ b/packages/server/src/attestation/verifyAttestationResponse.test.ts
@@ -1,13 +1,11 @@
 import base64url from 'base64url';
 
-import verifyAttestationResponse from './verifyAttestationResponse';
+import verifyAttestationResponse, { defaultFormatVerifiers } from './verifyAttestationResponse';
 
 import * as decodeAttestationObject from '../helpers/decodeAttestationObject';
 import * as decodeClientDataJSON from '../helpers/decodeClientDataJSON';
 import * as parseAuthenticatorData from '../helpers/parseAuthenticatorData';
 import * as decodeCredentialPublicKey from '../helpers/decodeCredentialPublicKey';
-
-import * as verifyFIDOU2F from './verifications/verifyFIDOU2F';
 
 import toHash from '../helpers/toHash';
 import { AttestationCredentialJSON } from '@simplewebauthn/typescript-types';
@@ -23,7 +21,10 @@ beforeEach(() => {
   mockDecodeClientData = jest.spyOn(decodeClientDataJSON, 'default');
   mockParseAuthData = jest.spyOn(parseAuthenticatorData, 'default');
   mockDecodePubKey = jest.spyOn(decodeCredentialPublicKey, 'default');
-  mockVerifyFIDOU2F = jest.spyOn(verifyFIDOU2F, 'default');
+  mockVerifyFIDOU2F = jest.spyOn(
+    defaultFormatVerifiers,
+    decodeAttestationObject.ATTESTATION_FORMAT.FIDO_U2F,
+  );
 });
 
 afterEach(() => {

--- a/packages/server/src/attestation/verifyAttestationResponse.ts
+++ b/packages/server/src/attestation/verifyAttestationResponse.ts
@@ -191,10 +191,6 @@ export class AttestationResponseVerifier {
     /**
      * Verification can only be performed when attestation = 'direct'
      */
-    if (!(fmt in this.formatVerifiers)) {
-      throw new Error(`Unsupported Attestation Format: ${fmt}`);
-    }
-
     const verifier = this.formatVerifiers[fmt];
     if (!verifier) {
       throw new Error(`Unsupported Attestation Format: ${fmt}`);


### PR DESCRIPTION
👋  @MasterKale per discussion #124, this is a PR to parameterize the apple verifier root certificate.

> There are a small number of root certificates that are currently baked into the library (not just Apple-related) that really should be default values that can then be overridden by environment variables.

I didn't go with environment variables because that wouldn't allow for arbitrary coupling of data and logic. Using an environment variable would limit us to one value per process. In my particular use case - I want to support both Apple WebAuthn with their WebAuthn Root CA AND Apple App Attest with their App Attest Root CA.

Conceptually, I'm going for a dependency injection strategy (vs option threading). I maintained the existing interfaces by using the default exports to export instances configured with the default settings.

I think I saw another PR in the past that used classes, and it wasn't appealing. I can swap the classes for function factories if you want. I thought I'd get your feedback on using classes first because they offer better performance if constructed frequently (admittedly, these shouldn't be), and I think they're a little easier to maintain.

The diff is a bit messy, so I'll try to tag the interesting bits that changed. Once you've weighed in on the strategy, I'll follow up with some new test, and I can apply the strategy to the other relevant places.