### PR TITLE
Fixed invalid format of ES modules that caused compiling issues for Vite

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "SimpleWebAuthn for Browsers",
   "main": "dist/es5/index.js",
-  "main:es2018": "dist/es2018/index.js",
+  "module": "dist/es2018/index.mjs",
   "types": "dist/types/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -52,7 +52,7 @@ export default [
       {
         dir: 'dist',
         format: 'esm',
-        entryFileNames: 'es2018/[name].js',
+        entryFileNames: 'es2018/[name].mjs',
         preferConst: true,
       },
       {


### PR DESCRIPTION
This pull request fixes an issue where `@simplewebauthn/browser` cannot be imported, because it causes Vite to error because Vite doesnt look for the `main:es2018`, but instead looks for `module`, which it can't find.