### PR TITLE
feat/default-to-es2018-bundle

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -9,14 +9,9 @@
 - [@simplewebauthn/browser](#simplewebauthnbrowser)
   - [Installation](#installation)
     - [UMD](#umd)
-      - [ES5](#es5)
       - [ES2018](#es2018)
+      - [ES5](#es5)
   - [Usage](#usage)
-  - [Building for Production](#building-for-production)
-    - [ES5](#es5-1)
-    - [ES2018](#es2018-1)
-      - [Webpack support](#webpack-support)
-      - [Rollup support](#rollup-support)
 
 ## Installation
 
@@ -32,15 +27,6 @@ This package can also be installed via **unpkg** by including the following scri
 
 > NOTE: The only difference between the two packages below is that the ES5 bundle includes TypeScript's `tslib` runtime code. This adds some bundle size overhead, but _does_ enable use of `supportsWebAuthn()` in older browsers to show appropriate UI when WebAuthn is unavailable.
 
-#### ES5
-
-If you need to support WebAuthn feature detection in deprecated browsers like IE11 and Edge Legacy, include the `ES5` version:
-
-```html
-
-<script src="https://unpkg.com/@simplewebauthn/browser/dist/es5/index.umd.min.js"></script>
-```
-
 #### ES2018
 
 If you only need to support modern browsers, include the `ES2018` version:
@@ -50,66 +36,15 @@ If you only need to support modern browsers, include the `ES2018` version:
 <script src="https://unpkg.com/@simplewebauthn/browser/dist/es2018/index.umd.min.js"></script>
 ```
 
+#### ES5
+
+If you need to support WebAuthn feature detection in deprecated browsers like IE11 and Edge Legacy, include the `ES5` version:
+
+```html
+
+<script src="https://unpkg.com/@simplewebauthn/browser/dist/es5/index.umd.min.js"></script>
+```
+
 ## Usage
 
 You can find in-depth documentation on this package here: https://simplewebauthn.dev/docs/packages/browser
-
-## Building for Production
-
-Two unbundled versions of this library are offered for your convenience, one targeting `ES5` and a second targeting `ES2018`.
-
-### ES5
-
-The `ES5` version is suitable for use when **deprecated browsers** like IE10+ or Edge Legacy need to be supported. This version is also the **default** version that gets pulled in as the `"main"` entry in **package.json**.
-
-TypeScript and JavaScript codebases alike can import and use this library without any special build configuration considerations.
-
-However, you will need to ensure that the `tslib` dependency gets pulled into your build artifact:
-
-- If you are authoring your application in TypeScript then this package will be **automatically** included so long as your **tsconfig.json** sets `"target": "ES5"`.
-- If your application is written in Javascript then you will need to install this package **manually** by adding it to `dependencies` in your project's **package. json**:
-
-```sh
-$> npm install tslib
-```
-
-### ES2018
-
-The `ES2018` version is suitable for use when only **modern browsers** need to be supported. TypeScript and JavaScript codebases alike can import and use this library. However, you will need to ensure that your bundler pulls in the ES2018 version of the library when building your application!
-
-See bundler instructions below.
-
-#### Webpack support
-
-No matter the `"target"` of your build you'll need to indicate additional files for webpack to resolve via the [`"resolve.mainFields"`](https://webpack.js.org/configuration/resolve/#resolvemainfields) property in your config. Resolve the `"main:es2018"` field defined in **package.json**:
-
-```js
-module.exports = {
-  //...
-  resolve: {
-    mainFields: [ 'main:es2018', 'module', 'main' ],
-  },
-};
-```
-
-`'main:es2018'` must come first in the list to ensure that the `ES2018` version of this library is bundled. Additional values can be added afterwards as needed.
-
-#### Rollup support
-
-Add the [`@rollup/plugin-node-resolve`](https://github.com/rollup/rollup-plugin-node-resolve#usage) plugin to your Rollup config to read in the `"main:es2018"` field from **package.json**:
-
-```js
-// rollup.config.js
-import resolve from 'rollup-plugin-node-resolve';
-
-export default {
-  // input: ...
-  // output: ...
-  plugins: [
-    //...
-    resolve({ mainFields: [ 'main:es2018', 'module', 'main' ] }),
-  ]
-}
-```
-
-`'main:es2018'` must come first in the list to ensure that the `ES2018` version of this library is bundled. Additional values can be added afterwards as needed.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -28,9 +28,6 @@
     "fido",
     "umd"
   ],
-  "peerDependencies": {
-    "tslib": "^2.2.0"
-  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0",
   "description": "SimpleWebAuthn for Browsers",
   "main": "dist/es5/index.js",
-  "main:es2018": "dist/es2018/index.js",
   "types": "dist/types/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,7 +2,7 @@
   "name": "@simplewebauthn/browser",
   "version": "3.0.0",
   "description": "SimpleWebAuthn for Browsers",
-  "main": "dist/es5/index.js",
+  "main": "dist/es2018/index.js",
   "types": "dist/types/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -69,17 +69,6 @@ export default [
     input: 'src/index.ts',
     output: {
       dir: 'dist',
-      format: 'cjs',
-      entryFileNames: 'es5/[name].js',
-      exports: 'auto',
-    },
-    plugins: [typescript({ tsconfig: './tsconfig.es5.json' }), nodeResolve(), swanVersionInjector],
-    external: ['tslib'],
-  },
-  {
-    input: 'src/index.ts',
-    output: {
-      dir: 'dist',
       format: 'umd',
       name: 'SimpleWebAuthnBrowser',
       entryFileNames: 'es5/[name].umd.min.js',


### PR DESCRIPTION
This PR reorganizes @simplewebauthn/browser to use the ES2018 bundle for `"main"` in **package.json**. The ES5 CommonJS bundle will no longer be maintained. Both the ES2018 and ES5 UMD bundles will continue to be maintained for now.

I've also cleaned up the README to remove references to the CJS ES5 bundle.