### PR TITLE
feat/improved-buffer-slicing

### DIFF
--- a/packages/server/src/attestation/verifications/tpm/parseCertInfo.ts
+++ b/packages/server/src/attestation/verifications/tpm/parseCertInfo.ts
@@ -4,32 +4,25 @@ import { TPM_ST, TPM_ALG } from './constants';
  * Cut up a TPM attestation's certInfo into intelligible chunks
  */
 export default function parseCertInfo(certInfo: Buffer): ParsedCertInfo {
-  let certBuffer = certInfo;
+  let pointer = 0;
 
   // Get a magic constant
-  const magic = certBuffer.slice(0, 4).readUInt32BE(0);
-  certBuffer = certBuffer.slice(4);
+  const magic = certInfo.slice(pointer, (pointer += 4)).readUInt32BE(0);
 
   // Determine the algorithm used for attestation
-  const typeBuffer = certBuffer.slice(0, 2);
-  certBuffer = certBuffer.slice(2);
+  const typeBuffer = certInfo.slice(pointer, (pointer += 2));
   const type = TPM_ST[typeBuffer.readUInt16BE(0)];
 
   // The name of a parent entity, can be ignored
-  const qualifiedSignerLength = certBuffer.slice(0, 2).readUInt16BE(0);
-  certBuffer = certBuffer.slice(2);
-  const qualifiedSigner = certBuffer.slice(0, qualifiedSignerLength);
-  certBuffer = certBuffer.slice(qualifiedSignerLength);
+  const qualifiedSignerLength = certInfo.slice(pointer, (pointer += 2)).readUInt16BE(0);
+  const qualifiedSigner = certInfo.slice(pointer, (pointer += qualifiedSignerLength));
 
   // Get the expected hash of `attsToBeSigned`
-  const extraDataLength = certBuffer.slice(0, 2).readUInt16BE(0);
-  certBuffer = certBuffer.slice(2);
-  const extraData = certBuffer.slice(0, extraDataLength);
-  certBuffer = certBuffer.slice(extraDataLength);
+  const extraDataLength = certInfo.slice(pointer, (pointer += 2)).readUInt16BE(0);
+  const extraData = certInfo.slice(pointer, (pointer += extraDataLength));
 
   // Information about the TPM device's internal clock, can be ignored
-  const clockInfoBuffer = certBuffer.slice(0, 17);
-  certBuffer = certBuffer.slice(17);
+  const clockInfoBuffer = certInfo.slice(pointer, (pointer += 17));
   const clockInfo = {
     clock: clockInfoBuffer.slice(0, 8),
     resetCount: clockInfoBuffer.slice(8, 12).readUInt32BE(0),
@@ -38,20 +31,15 @@ export default function parseCertInfo(certInfo: Buffer): ParsedCertInfo {
   };
 
   // TPM device firmware version
-  const firmwareVersion = certBuffer.slice(0, 8);
-  certBuffer = certBuffer.slice(8);
+  const firmwareVersion = certInfo.slice(pointer, (pointer += 8));
 
   // Attested Name
-  const attestedNameLength = certBuffer.slice(0, 2).readUInt16BE(0);
-  certBuffer = certBuffer.slice(2);
-  const attestedName = certBuffer.slice(0, attestedNameLength);
-  certBuffer = certBuffer.slice(attestedNameLength);
+  const attestedNameLength = certInfo.slice(pointer, (pointer += 2)).readUInt16BE(0);
+  const attestedName = certInfo.slice(pointer, (pointer += attestedNameLength));
 
   // Attested qualified name, can be ignored
-  const qualifiedNameLength = certBuffer.slice(0, 2).readUInt16BE(0);
-  certBuffer = certBuffer.slice(2);
-  const qualifiedName = certBuffer.slice(0, qualifiedNameLength);
-  certBuffer = certBuffer.slice(qualifiedNameLength);
+  const qualifiedNameLength = certInfo.slice(pointer, (pointer += 2)).readUInt16BE(0);
+  const qualifiedName = certInfo.slice(pointer, (pointer += qualifiedNameLength));
 
   const attested = {
     nameAlg: TPM_ALG[attestedName.slice(0, 2).readUInt16BE(0)],


### PR DESCRIPTION
This PR simplifies buffer manipulation in several `parse...()` methods. Instead of re-slicing the main buffer every time...

```js
const someBuffer = bigBuffer.slice(0, 16);
bigBuffer = bigBuffer.slice(16);
const otherBuffer = bigBuffer.slice(0, 2);
bigBuffer = bigBuffer.slice(2);
```

...these methods now use a "pointer" and addition assignment:

```js
let pointer = 0;
const someBuffer = bigBuffer.slice(pointer, pointer += 16);
const otherBuffer = bigBuffer.slice(pointer, pointer += 2);
```