### PR TITLE
feat/example-debug-console

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -182,6 +182,7 @@ app.post('/verify-attestation', async (req, res) => {
         credentialPublicKey,
         credentialID,
         counter,
+        transports: body.transports,
       };
       user.devices.push(newDevice);
     }
@@ -202,7 +203,7 @@ app.get('/generate-assertion-options', (req, res) => {
     allowCredentials: user.devices.map(dev => ({
       id: dev.credentialID,
       type: 'public-key',
-      transports: ['usb', 'ble', 'nfc', 'internal'],
+      transports: dev.transports ?? ['usb', 'ble', 'nfc', 'internal'],
     })),
     /**
      * This optional value controls whether or not the authenticator needs be able to uniquely

--- a/example/index.ts
+++ b/example/index.ts
@@ -133,6 +133,10 @@ app.get('/generate-attestation-options', (req, res) => {
       userVerification: 'preferred',
       requireResidentKey: false,
     },
+    /**
+     * Support the two most common algorithms: ES256, and RS256
+     */
+    supportedAlgorithmIDs: [-7, -257],
   };
 
   const options = generateAttestationOptions(opts);

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -42,6 +42,9 @@
     <script>
       const { supportsWebauthn, startAttestation, startAssertion } = SimpleWebAuthnBrowser;
 
+      /**
+       * A simple way to control how debug content is written to a debug console element
+       */
       function printDebug(elemDebug, title, output) {
         if (elemDebug.innerHTML !== '') {
           elemDebug.innerHTML += '\n';

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -42,6 +42,14 @@
     <script>
       const { supportsWebauthn, startAttestation, startAssertion } = SimpleWebAuthnBrowser;
 
+      function printDebug(elemDebug, title, output) {
+        if (elemDebug.innerHTML !== '') {
+          elemDebug.innerHTML += '\n';
+        }
+        elemDebug.innerHTML += `// ${title}\n`;
+        elemDebug.innerHTML += `${output}\n`;
+      }
+
       // Hide the Begin button if the browser is incapable of using WebAuthn
       if (!supportsWebauthn()) {
         document.querySelector('.controls').style.display = 'none';
@@ -54,16 +62,21 @@
         document.querySelector('#btnRegBegin').addEventListener('click', async () => {
           const elemSuccess = document.querySelector('#regSuccess');
           const elemError = document.querySelector('#regError');
+          const elemDebug = document.querySelector('#regDebug');
 
           // Reset success/error messages
           elemSuccess.innerHTML = '';
           elemError.innerHTML = '';
+          elemDebug.innerHTML = '';
 
           const resp = await fetch('/generate-attestation-options');
 
           let attResp;
           try {
-            attResp = await startAttestation(await resp.json());
+            const opts = await resp.json();
+            printDebug(elemDebug, 'Registration Options', JSON.stringify(opts, null, 2));
+            attResp = await startAttestation(opts);
+            printDebug(elemDebug, 'Registration Response', JSON.stringify(attResp, null, 2));
           } catch (error) {
             if (error.name === 'InvalidStateError') {
               elemError.innerText = 'Error: Authenticator was probably already registered by user';
@@ -83,6 +96,7 @@
           });
 
           const verificationJSON = await verificationResp.json();
+          printDebug(elemDebug, 'Server Response', JSON.stringify(verificationJSON, null, 2));
 
           if (verificationJSON && verificationJSON.verified) {
             elemSuccess.innerHTML = `Authenticator registered!`;
@@ -99,17 +113,21 @@
         document.querySelector('#btnAuthBegin').addEventListener('click', async () => {
           const elemSuccess = document.querySelector('#authSuccess');
           const elemError = document.querySelector('#authError');
+          const elemDebug = document.querySelector('#authDebug');
 
           // Reset success/error messages
           elemSuccess.innerHTML = '';
           elemError.innerHTML = '';
+          elemDebug.innerHTML = '';
 
           const resp = await fetch('/generate-assertion-options');
 
           let asseResp;
           try {
             const opts = await resp.json();
+            printDebug(elemDebug, 'Authentication Options', JSON.stringify(opts, null, 2));
             asseResp = await startAssertion(opts);
+            printDebug(elemDebug, 'Authentication Response', JSON.stringify(asseResp, null, 2));
           } catch (error) {
             elemError.innerText = error;
             throw new Error(error);
@@ -124,6 +142,7 @@
           });
 
           const verificationJSON = await verificationResp.json();
+          printDebug(elemDebug, 'Server Response', JSON.stringify(verificationJSON, null, 2));
 
           if (verificationJSON && verificationJSON.verified) {
             elemSuccess.innerHTML = `User authenticated!`;

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -18,6 +18,10 @@
           </button>
           <p id="regSuccess" class="success"></p>
           <p id="regError" class="error"></p>
+          <details open>
+            <summary>Console</summary>
+            <textarea id="regDebug" spellcheck="false"></textarea>
+          </details>
         </section>
 
         <section id="authentication">
@@ -26,6 +30,10 @@
           </button>
           <p id="authSuccess" class="success"></p>
           <p id="authError" class="error"></p>
+          <details open>
+            <summary>Console</summary>
+            <textarea id="authDebug" spellcheck="false"></textarea>
+          </details>
         </section>
       </div>
 

--- a/example/public/styles.css
+++ b/example/public/styles.css
@@ -32,6 +32,10 @@ button:hover {
   background: #efefef;
 }
 
+details {
+  margin-top: 0.75rem;
+}
+
 .container {
   max-width: 70rem;
   margin: auto;
@@ -44,6 +48,17 @@ button:hover {
 
 .success {
   color: #11a000;
+}
+
+#regDebug, #authDebug {
+  background: #efefef;
+  border-radius: 0.25rem;
+  text-align: left;
+  font-size: 0.7rem;
+  padding: 0.5rem;
+  height: 15rem;
+  width: 95%;
+  overflow-y: auto;
 }
 
 /* Desktop Styles */

--- a/example/public/styles.css
+++ b/example/public/styles.css
@@ -1,3 +1,11 @@
+:root {
+  --background: #f7f7f7;
+  --text: black;
+  --button: white;
+  --button-active: #eeeeee;
+  --button-hover: #efefef;
+}
+
 * {
   font-size: 16px;
   font-family: 'Courier New', Courier, monospace;
@@ -10,7 +18,8 @@ body {
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background: #f7f7f7;
+  background: var(--background);
+  color: var(--text);
 }
 
 h1 {
@@ -19,17 +28,18 @@ h1 {
 
 button {
   padding: 0.5rem;
-  background: white;
+  background: var(--button);
+  color: var(--text);
   border-radius: 0.25rem;
   width: 13rem;
 }
 
 button:active {
-  background: #eeeeee;
+  background: var(--button-active);
 }
 
 button:hover {
-  background: #efefef;
+  background: var(--button-hover);
 }
 
 details {
@@ -52,7 +62,8 @@ details {
 }
 
 #regDebug, #authDebug {
-  background: #efefef;
+  background: var(--button-hover);
+  color: var(--text);
   border-radius: 0.25rem;
   text-align: left;
   font-size: 0.7rem;
@@ -70,5 +81,15 @@ details {
 
   .container {
     width: 45rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1c2128;
+    --text: #adbac7;
+    --button: #373e47;
+    --button-active: #eeeeee;
+    --button-hover: #444c56;
   }
 }

--- a/example/public/styles.css
+++ b/example/public/styles.css
@@ -37,9 +37,10 @@ details {
 }
 
 .container {
-  max-width: 70rem;
+  width: 95%;
   margin: auto;
   text-align: center;
+  padding: 0.5rem;
 }
 
 .error {
@@ -64,6 +65,10 @@ details {
 /* Desktop Styles */
 @media (min-width: 75rem) {
   * {
-    font-size: 24px;
+    font-size: 20px;
+  }
+
+  .container {
+    width: 45rem;
   }
 }

--- a/example/public/styles.css
+++ b/example/public/styles.css
@@ -43,7 +43,7 @@ button:hover {
 }
 
 details {
-  margin-top: 0.75rem;
+  margin: 0.75rem 0;
 }
 
 .container {


### PR DESCRIPTION
This PR adds "debug consoles" to the example site UI. During registration and authentication the following JSON objects are output to it:

- WebAuthn API options
- Authenticator response
- Server response

One small backend improvement includes the persistence and inclusion of the actual authenticator's `transports`, to reflect the intended use of this value to control authenticator selection for authentication.

New UI:

![Screen Shot 2021-07-08 at 9 54 34 PM](https://user-images.githubusercontent.com/5166470/125025465-8f7ba400-e037-11eb-99c9-baf8b0e390ba.png)

I also added a dark mode page style:

![Screen Shot 2021-07-08 at 9 54 12 PM](https://user-images.githubusercontent.com/5166470/125025473-92769480-e037-11eb-9a26-b6c6a419e4a5.png)