### PR TITLE
fix-browser-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ts-morph": "^11.0.3",
     "ts-node": "^10.2.1",
     "typedoc": "^0.21.6",
-    "typescript": "^4.3.5"
+    "typescript": "~4.3.5"
   },
   "husky": {
     "hooks": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,7 +35,8 @@
     "@simplewebauthn/typescript-types": "file:../typescript-types",
     "rollup": "^2.52.1",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-version-injector": "^1.3.3"
+    "rollup-plugin-version-injector": "^1.3.3",
+    "typescript": "~4.3.5"
   },
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498"
 }


### PR DESCRIPTION
CI started hanging because `typescript@4.4.2` dropped and there's an issue with `@rollup/plugin-typescript` and this latest version of TypeScript.

See https://github.com/rollup/plugins/issues/983

This PR keeps **@simplewebauthn/browser** on `typescript@~4.3.5` for now. I'll keep an eye on that Rollup issue and remove this restriction once `@rollup/plugin-typescript` gets updated.