### PR TITLE
fix/browser-isuvpaa-detect-webauthn-support

### DIFF
--- a/packages/browser/src/helpers/platformAuthenticatorIsAvailable.test.ts
+++ b/packages/browser/src/helpers/platformAuthenticatorIsAvailable.test.ts
@@ -6,9 +6,8 @@ beforeEach(() => {
   mockIsUVPAA.mockReset();
 
   // @ts-ignore 2741
-  window.PublicKeyCredential = {
-    isUserVerifyingPlatformAuthenticatorAvailable: mockIsUVPAA.mockResolvedValue(true),
-  };
+  window.PublicKeyCredential = jest.fn().mockReturnValue(() => {});
+  window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = mockIsUVPAA.mockResolvedValue(true);
 });
 
 test('should return true when platform authenticator is available', async () => {
@@ -20,6 +19,13 @@ test('should return true when platform authenticator is available', async () => 
 test('should return false when platform authenticator is unavailable', async () => {
   mockIsUVPAA.mockResolvedValue(false);
 
+  const isAvailable = await platformAuthenticatorIsAvailable();
+
+  expect(isAvailable).toEqual(false);
+});
+
+test('should return false when browser does not support WebAuthn', async () => {
+  delete (window as any).PublicKeyCredential;
   const isAvailable = await platformAuthenticatorIsAvailable();
 
   expect(isAvailable).toEqual(false);

--- a/packages/browser/src/helpers/platformAuthenticatorIsAvailable.ts
+++ b/packages/browser/src/helpers/platformAuthenticatorIsAvailable.ts
@@ -1,3 +1,5 @@
+import { browserSupportsWebauthn } from './browserSupportsWebauthn';
+
 /**
  * Determine whether the browser can communicate with a built-in authenticator, like
  * Touch ID, Android fingerprint scanner, or Windows Hello.
@@ -5,5 +7,9 @@
  * This method will _not_ be able to tell you the name of the platform authenticator.
  */
 export async function platformAuthenticatorIsAvailable(): Promise<boolean> {
+  if (!browserSupportsWebauthn()) {
+    return false;
+  }
+
   return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
 }


### PR DESCRIPTION
`platformAuthenticatorIsAvailable()` errors out with "PublicKeyCredential is not defined" if the browser doesn't support WebAuthn. This PR adds in a check that WebAuthn is supported before trying to query for the status of the platform authenticator.

Fixes #154.