### PR TITLE
feat/mds-allow-statement-cache-miss

### DIFF
--- a/packages/server/src/services/metadataService.test.ts
+++ b/packages/server/src/services/metadataService.test.ts
@@ -79,6 +79,18 @@ describe('Method: getStatement()', () => {
       expect(err).not.toBeUndefined();
     }
   });
+
+  test('should return undefined after initialization on AAGUID with no statement and allowUnrecognizedAAGUID is true', async () => {
+    await MetadataService.initialize({
+      mdsServers: [],
+      statements: [],
+      allowUnrecognizedAAGUID: true,
+    });
+
+    const statement = await MetadataService.getStatement('not-a-real-aaguid');
+
+    expect(statement).toBeUndefined();
+  });
 });
 
 const localStatementAAGUID = '91dfead7-959e-4475-ad26-9b0d482be089';

--- a/packages/server/src/services/metadataService.test.ts
+++ b/packages/server/src/services/metadataService.test.ts
@@ -80,11 +80,11 @@ describe('Method: getStatement()', () => {
     }
   });
 
-  test('should return undefined after initialization on AAGUID with no statement and allowUnrecognizedAAGUID is true', async () => {
+  test('should return undefined after initialization on AAGUID with no statement and verificationMode is "permissive"', async () => {
     await MetadataService.initialize({
       mdsServers: [],
       statements: [],
-      allowUnrecognizedAAGUID: true,
+      verificationMode: 'permissive',
     });
 
     const statement = await MetadataService.getStatement('not-a-real-aaguid');

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -158,7 +158,7 @@ export class BaseMetadataService {
 
     if (!cachedStatement) {
       if (this.verificationMode === 'strict') {
-        // FIDO conformance requires RP's to only support AAGUID's that have metadata statements
+        // FIDO conformance requires RP's to only support registered AAGUID's
         throw new Error(`No metadata statement found for aaguid "${aaguid}"`);
       }
 

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -36,6 +36,8 @@ enum SERVICE_STATE {
   READY,
 }
 
+// Allow MetadataService to accommodate unregistered AAGUIDs ("permissive"), or only allow
+// registered AAGUIDs ("strict"). Currently primarily impacts how `getStatement()` operates
 type VerificationMode = 'permissive' | 'strict';
 
 /**
@@ -59,8 +61,9 @@ export class BaseMetadataService {
    * (version 3.0)-compatible servers. Defaults to the official FIDO MDS server
    * @param opts.statements An array of local metadata statements
    * @param opts.verificationMode How MetadataService will handle unregistered AAGUIDs. Defaults to
-   * `"strict"` which throws errors when an unregistered AAGUID is encountered during registration.
-   * Set to `"permissive"` to allow registration by authenticators with unregistered AAGUIDs
+   * `"strict"` which throws errors during registration response verification when an
+   * unregistered AAGUID is encountered. Set to `"permissive"` to allow registration by
+   * authenticators with unregistered AAGUIDs
    */
   async initialize(
     opts: {
@@ -129,7 +132,7 @@ export class BaseMetadataService {
   }
 
   /**
-   * Get a metadata statement for a given aaguid. Defaults to returning a cached statement.
+   * Get a metadata statement for a given AAGUID.
    *
    * This method will coordinate updating the cache as per the `nextUpdate` property in the initial
    * BLOB download.


### PR DESCRIPTION
FIDO conformance testing requires RP's to fail registration response verification if an authenticator's AAGUID does not correspond to a registered metadata statement. This has always seemed particularly onerous to me, and I've never managed to find a good reason for why this is the case, so I'm finally adding in a flag to `MetadataService.initialize()` that allows RP admins to continue with verification anyway.

This addresses #155.