### PR TITLE
feat/logging-take-2

### DIFF
--- a/example/fido-conformance.ts
+++ b/example/fido-conformance.ts
@@ -74,10 +74,6 @@ fetch('https://mds3.certinfra.fidoalliance.org/getEndpoints', {
   })
   .catch(console.error)
   .finally(() => {
-    if (statements.length) {
-      console.log(`ℹ️  Initializing metadata service with ${statements.length} local statements`);
-    }
-
     console.log('🔐 FIDO Conformance routes ready');
   });
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -52,6 +52,7 @@
     "@simplewebauthn/typescript-types": "file:../typescript-types",
     "base64url": "^3.0.1",
     "cbor": "^5.1.0",
+    "debug": "^4.3.2",
     "elliptic": "^6.5.3",
     "jsrsasign": "^10.4.0",
     "jwk-to-pem": "^2.0.4",
@@ -61,6 +62,7 @@
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498",
   "devDependencies": {
     "@types/cbor": "^5.0.1",
+    "@types/debug": "^4.1.7",
     "@types/elliptic": "^6.4.13",
     "@types/jsrsasign": "^8.0.13",
     "@types/jwk-to-pem": "^2.0.1",

--- a/packages/server/src/helpers/logging.ts
+++ b/packages/server/src/helpers/logging.ts
@@ -1,0 +1,21 @@
+import debug, { Debugger } from 'debug';
+
+const defaultLogger = debug('SimpleWebAuthn');
+
+/**
+ * Generate an instance of a `debug` logger that extends off of the "simplewebauthn" namespace for
+ * consistent naming.
+ *
+ * See https://www.npmjs.com/package/debug for information on how to control logging output when
+ * using @simplewebauthn/server
+ *
+ * Example:
+ *
+ * ```
+ * const log = getLogger('mds');
+ * log('hello'); // simplewebauthn:mds hello +0ms
+ * ```
+ */
+export function getLogger(name: string): Debugger {
+  return defaultLogger.extend(name);
+}

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -127,7 +127,7 @@ export class BaseMetadataService {
       // Calculate the difference to get the total number of new statements we successfully added
       const newCacheCount = Object.keys(this.statementCache).length;
       const cacheDiff = newCacheCount - currentCacheCount;
-      log(`Cached ${cacheDiff} statements from ${numServers} metadata servers`);
+      log(`Cached ${cacheDiff} statements from ${numServers} metadata server(s)`);
     }
 
     if (verificationMode) {

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -83,6 +83,8 @@ export class BaseMetadataService {
 
     // If metadata statements are provided, load them into the cache first
     if (statements?.length) {
+      let statementsAdded = 0;
+
       statements.forEach(statement => {
         // Only cache statements that are for FIDO2-compatible authenticators
         if (statement.aaguid) {
@@ -94,8 +96,12 @@ export class BaseMetadataService {
             },
             url: '',
           };
+
+          statementsAdded += 1;
         }
       });
+
+      log(`Cached ${statementsAdded} local statements`);
     }
 
     // If MDS servers are provided, then process them and add their statements to the cache


### PR DESCRIPTION
Taking another stab at implementing logging output in `MetadataService`, this time using the [`debug`](https://www.npmjs.com/package/debug) library directly.

Here's what it looks like when the example project adds the new `DEBUG=SimpleWebAuthn:*` environment variable:

```txt
🚀 Server ready at http://localhost:8000 (127.0.0.1:8000)
  SimpleWebAuthn:MetadataService MetadataService is REFRESHING +0ms
  SimpleWebAuthn:MetadataService Cached 21 local statements +0ms
  SimpleWebAuthn:MetadataService Could not download BLOB from https://mds3.certinfra.fidoalliance.org/execute/07f2d7b0561be25d17830ccb0a28bfb3ffb661e40c2531805a5701a54ea53737: Error: BLOB certificate path could not be validated: Subject issuer did not match issuer subject
    at BaseMetadataService.downloadBlob (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:236:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async BaseMetadataService.initialize (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:115:11) +583ms
  SimpleWebAuthn:MetadataService Could not download BLOB from https://mds3.certinfra.fidoalliance.org/execute/14dfc54b3a0d921dd77d90d8c9143ba5c77ebe5bbc0aed0424f16454356f0b9c: Error: BLOB signature could not be verified
    at BaseMetadataService.downloadBlob (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:251:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async BaseMetadataService.initialize (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:115:11) +1s
  SimpleWebAuthn:MetadataService Could not download BLOB from https://mds3.certinfra.fidoalliance.org/execute/8165f3b81c69edc164898800338913c0950751e22e5e4e0818f6b375b49518ed: Error: BLOB certificate path could not be validated: Found revoked certificate in certificate path
    at BaseMetadataService.downloadBlob (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:236:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async BaseMetadataService.initialize (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:115:11) +1s
  SimpleWebAuthn:MetadataService Could not download BLOB from https://mds3.certinfra.fidoalliance.org/execute/defec195094d0400ef9979aae517e188ef7bb215d25c71a668375313157e6e8f: Error: BLOB certificate path could not be validated: Subject issuer did not match issuer subject
    at BaseMetadataService.downloadBlob (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:236:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async BaseMetadataService.initialize (/Users/matt/Repos/simplewebauthn/packages/server/src/services/metadataService.ts:115:11) +400ms
  SimpleWebAuthn:MetadataService Cached 100 statements from 1 metadata servers +0ms
  SimpleWebAuthn:MetadataService MetadataService is READY +0ms
🔐 FIDO Conformance routes ready
```

And if the console supports colors then it looks even nicer:

<img width="307" alt="Screen Shot 2021-09-09 at 9 52 59 PM" src="https://user-images.githubusercontent.com/5166470/132801579-d8d6c796-28a7-4c6e-a48c-a83e10eeb62d.png">

I'm pretty satisfied with how simple this will make it for library consumers to get logging output out of this library, so after this merges I'll consider adding more logging to other parts of the library to help with debugging if an errors occur. That'll likely involve a follow-up diff.