### PR TITLE
server/require-user-verification

### DIFF
--- a/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
@@ -175,7 +175,7 @@ test('should throw an error if user verification is required but user was not ve
       expectedOrigin: assertionOrigin,
       expectedRPID: 'dev.dontneeda.pw',
       authenticator: authenticator,
-      fidoUserVerification: 'required',
+      requireUserVerification: true,
     });
   }).toThrow(/user could not be verified/i);
 });


### PR DESCRIPTION
While dogfooding the server library I confused myself by not having a `requireUserVerification` option on `verifyAuthenticationResponse()` like there is on `verifyRegistrationResponse()`. Instead was the `fidoUserVerification` argument that felt clunky to use and actually ignored `up` if set to `"preferred"`.

I remembered I'd added `fidoUserVerification` to satisfy a few tests in FIDO Conformance testing that require you to **pass verification even when user presence was false or not set:**

![Screen Shot 2022-02-15 at 7 10 54 PM](https://user-images.githubusercontent.com/5166470/154414520-de2cb3a7-c9ee-4181-95bf-4b2aa57abcfa.png)

However, digging into _why_ FIDO Conformance required servers to support up not being true when the latest spec requires up to always be true, it seems in 2019 when WebAuthn was in a very early state there [was some discussion about the possibility of supporting "silent authentication"](https://github.com/w3c/webauthn/issues/199). The spec never adopted the idea and now, as of today, user presence _must_ be true.

[I'm attempting to reopen an issue in the FIDO Conformance Tools repo](https://github.com/fido-alliance/conformance-test-tools-resources/issues/434#issuecomment-1041053511) to get them to reconsider these three tests as I don't think they're relevant anymore given the evolution of WebAuthn over the last three years.

In the meantime I've prepped this diff to make `verifyAuthenticationResponse()` simpler to use by matching how `verifyRegistrationResponse()` allows you to require the `uv` flag be true.