### PR TITLE
feat/update-typescript-to-4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "ts-jest": "^27.0.5",
     "ts-morph": "^11.0.3",
     "ts-node": "^10.2.1",
-    "typedoc": "^0.21.6",
+    "typedoc": "^0.22.15",
+    "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "^4.6.3"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ts-morph": "^11.0.3",
     "ts-node": "^10.2.1",
     "typedoc": "^0.21.6",
-    "typescript": "~4.3.5"
+    "typescript": "^4.6.3"
   },
   "husky": {
     "hooks": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,8 +35,7 @@
     "@simplewebauthn/typescript-types": "file:../typescript-types",
     "rollup": "^2.52.1",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-version-injector": "^1.3.3",
-    "typescript": "~4.3.5"
+    "rollup-plugin-version-injector": "^1.3.3"
   },
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498"
 }

--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -15,6 +15,6 @@ export default function toPublicKeyCredentialDescriptor(
      * transports that TypeScript's DOM lib is ignorant of. Convince TS that our list of transports
      * are fine to pass to WebAuthn since browsers will recognize the new value.
      */
-     transports: descriptor.transports as AuthenticatorTransport[],
+    transports: descriptor.transports as AuthenticatorTransport[],
   };
 }

--- a/packages/server/src/helpers/convertPublicKeyToPEM.test.ts
+++ b/packages/server/src/helpers/convertPublicKeyToPEM.test.ts
@@ -61,7 +61,7 @@ test('should return pem when input is base64URLString', () => {
   try {
     convertPublicKeyToPEM(input);
   } catch(err) {
-    expect(err.message).toEqual("Public key was missing kty");
+    expect((err as Error).message).toEqual("Public key was missing kty");
   }
 });
 
@@ -76,6 +76,6 @@ test('should return pem when input is base64URLString', () => {
   try {
     convertPublicKeyToPEM(input);
   } catch(err) {
-    expect(err.message).toEqual("Could not convert public key type 1 to PEM");
+    expect((err as Error).message).toEqual("Could not convert public key type 1 to PEM");
   }
 });

--- a/packages/server/src/helpers/convertPublicKeyToPEM.ts
+++ b/packages/server/src/helpers/convertPublicKeyToPEM.ts
@@ -8,7 +8,8 @@ export default function convertPublicKeyToPEM(publicKey: Buffer): string {
   try {
     struct = cbor.decodeAllSync(publicKey)[0];
   } catch (err) {
-    throw new Error(`Error decoding public key while converting to PEM: ${err.message}`);
+    const _err = err as Error;
+    throw new Error(`Error decoding public key while converting to PEM: ${_err.message}`);
   }
 
   const kty = struct.get(COSEKEYS.kty);

--- a/packages/server/src/helpers/decodeCbor.ts
+++ b/packages/server/src/helpers/decodeCbor.ts
@@ -5,10 +5,20 @@ export function decodeCborFirst(input: string | Buffer | ArrayBufferView): any {
     // throws if there are extra bytes
     return cbor.decodeFirstSync(input);
   } catch (err) {
+    const _err = err as CborDecoderError;
     // if the error was due to extra bytes, return the unpacked value
-    if (err.value) {
-      return err.value;
+    if (_err.value) {
+      return _err.value;
     }
     throw err;
   }
+}
+
+/**
+ * Intuited from a quick scan of `cbor.decodeFirstSync()` here:
+ *
+ * https://github.com/hildjj/node-cbor/blob/v5.1.0/lib/decoder.js#L189
+ */
+class CborDecoderError extends Error {
+  value: any;
 }

--- a/packages/server/src/metadata/verifyAttestationWithMetadata.ts
+++ b/packages/server/src/metadata/verifyAttestationWithMetadata.ts
@@ -75,7 +75,8 @@ export default async function verifyAttestationWithMetadata(
       statement.attestationRootCertificates.map(convertCertBufferToPEM),
     );
   } catch (err) {
-    throw new Error(`Could not validate certificate path with any metadata root certificates: ${err.message}`);
+    const _err = err as Error;
+    throw new Error(`Could not validate certificate path with any metadata root certificates: ${_err.message}`);
   }
 
   return true;

--- a/packages/server/src/registration/verifications/tpm/verifyTPM.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyTPM.ts
@@ -263,14 +263,16 @@ export default async function verifyTPM(options: AttestationFormatVerifierOpts):
     try {
       await verifyAttestationWithMetadata(statement, credentialPublicKey, x5c);
     } catch (err) {
-      throw new Error(`${err.message} (TPM)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (TPM)`);
     }
   } else {
     try {
       // Try validating the certificate path using the root certificates set via SettingsService
       await validateCertificatePath(x5c.map(convertCertBufferToPEM), rootCertificates);
     } catch (err) {
-      throw new Error(`${err.message} (TPM)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (TPM)`);
     }
   }
 

--- a/packages/server/src/registration/verifications/verifyAndroidKey.ts
+++ b/packages/server/src/registration/verifications/verifyAndroidKey.ts
@@ -80,14 +80,16 @@ export default async function verifyAttestationAndroidKey(
     try {
       await verifyAttestationWithMetadata(statement, credentialPublicKey, x5c);
     } catch (err) {
-      throw new Error(`${err.message} (AndroidKey)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (AndroidKey)`);
     }
   } else {
     try {
       // Try validating the certificate path using the root certificates set via SettingsService
       await validateCertificatePath(x5c.map(convertCertBufferToPEM), rootCertificates);
     } catch (err) {
-      throw new Error(`${err.message} (AndroidKey)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (AndroidKey)`);
     }
   }
 

--- a/packages/server/src/registration/verifications/verifyAndroidSafetyNet.ts
+++ b/packages/server/src/registration/verifications/verifyAndroidSafetyNet.ts
@@ -97,14 +97,16 @@ export default async function verifyAttestationAndroidSafetyNet(
     try {
       await verifyAttestationWithMetadata(statement, credentialPublicKey, HEADER.x5c);
     } catch (err) {
-      throw new Error(`${err.message} (SafetyNet)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (SafetyNet)`);
     }
   } else {
     try {
       // Try validating the certificate path using the root certificates set via SettingsService
       await validateCertificatePath(HEADER.x5c.map(convertCertBufferToPEM), rootCertificates);
     } catch (err) {
-      throw new Error(`${err.message} (SafetyNet)`);
+      const _err = err as Error;
+      throw new Error(`${_err.message} (SafetyNet)`);
     }
   }
   /**

--- a/packages/server/src/registration/verifications/verifyApple.ts
+++ b/packages/server/src/registration/verifications/verifyApple.ts
@@ -24,7 +24,8 @@ export default async function verifyApple(
   try {
     await validateCertificatePath(x5c.map(convertCertBufferToPEM), rootCertificates);
   } catch (err) {
-    throw new Error(`${err.message} (Apple)`);
+    const _err = err as Error;
+    throw new Error(`${_err.message} (Apple)`);
   }
 
   /**

--- a/packages/server/src/registration/verifications/verifyFIDOU2F.ts
+++ b/packages/server/src/registration/verifications/verifyFIDOU2F.ts
@@ -52,7 +52,8 @@ export default async function verifyAttestationFIDOU2F(
     // Try validating the certificate path using the root certificates set via SettingsService
     await validateCertificatePath(x5c.map(convertCertBufferToPEM), rootCertificates);
   } catch (err) {
-    throw new Error(`${err.message} (FIDOU2F)`);
+    const _err = err as Error;
+    throw new Error(`${_err.message} (FIDOU2F)`);
   }
 
   const leafCertPEM = convertCertBufferToPEM(x5c[0]);

--- a/packages/server/src/registration/verifications/verifyPacked.ts
+++ b/packages/server/src/registration/verifications/verifyPacked.ts
@@ -100,14 +100,16 @@ export default async function verifyAttestationPacked(
       try {
         await verifyAttestationWithMetadata(statement, credentialPublicKey, x5c);
       } catch (err) {
-        throw new Error(`${err.message} (Packed|Full)`);
+        const _err = err as Error;
+        throw new Error(`${_err.message} (Packed|Full)`);
       }
     } else {
       try {
         // Try validating the certificate path using the root certificates set via SettingsService
         await validateCertificatePath(x5c.map(convertCertBufferToPEM), rootCertificates);
       } catch (err) {
-        throw new Error(`${err.message} (Packed|Full)`);
+        const _err = err as Error;
+        throw new Error(`${_err.message} (Packed|Full)`);
       }
     }
 


### PR DESCRIPTION
~~This PR adds support for the new `"cable"` transport that enables platform authenticators on mobile devices to be used for authentication on desktops. Chrome and Safari are both demonstrating opt-in support for this capability ahead of a presumed launch of the feature sometime in June, and so this should future-proof SimpleWebAuthn.~~ (Superseded by PR #198)

This PR now updates TypeScript to 4.6. TypeDoc complained about peer dependencies not matching up afterwards so I'm including an update to TypeDoc as well.