### PR TITLE
fix/authenticator-transports-override

### DIFF
--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -1,7 +1,7 @@
 import type {
   AuthenticationExtensionsClientInputs,
   PublicKeyCredentialRequestOptionsJSON,
-  PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorFuture,
   UserVerificationRequirement,
 } from '@simplewebauthn/typescript-types';
 import base64url from 'base64url';
@@ -9,7 +9,7 @@ import base64url from 'base64url';
 import generateChallenge from '../helpers/generateChallenge';
 
 export type GenerateAuthenticationOptionsOpts = {
-  allowCredentials?: PublicKeyCredentialDescriptor[];
+  allowCredentials?: PublicKeyCredentialDescriptorFuture[];
   challenge?: string | Buffer;
   timeout?: number;
   userVerification?: UserVerificationRequirement;

--- a/packages/server/src/helpers/convertCertBufferToPEM.test.ts
+++ b/packages/server/src/helpers/convertCertBufferToPEM.test.ts
@@ -20,7 +20,7 @@ dHJpbmcgY2VydEJ1ZmZlclN0cmluZw==
 });
 
 test('should return pem when input is buffer', () => {
-  const input = new Buffer(128);
+  const input = Buffer.alloc(128);
   const actual = convertCertBufferToPEM(input);
   const actualPemArr = actual.split("\n");
   expect(actual).toEqual(`-----BEGIN CERTIFICATE-----

--- a/packages/server/src/helpers/toHash.test.ts
+++ b/packages/server/src/helpers/toHash.test.ts
@@ -6,6 +6,6 @@ test('should return a buffer of at 32 bytes for input string', () => {
 });
 
 test('should return a buffer of at 32 bytes for input Buffer', () => {
-  const hash = toHash(new Buffer(10));
+  const hash = toHash(Buffer.alloc(10));
   expect(hash.byteLength).toEqual(32);
 });

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -4,7 +4,7 @@ import type {
   AuthenticatorSelectionCriteria,
   COSEAlgorithmIdentifier,
   PublicKeyCredentialCreationOptionsJSON,
-  PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorFuture,
   PublicKeyCredentialParameters,
 } from '@simplewebauthn/typescript-types';
 import base64url from 'base64url';
@@ -20,7 +20,7 @@ export type GenerateRegistrationOptionsOpts = {
   userDisplayName?: string;
   timeout?: number;
   attestationType?: AttestationConveyancePreference;
-  excludeCredentials?: PublicKeyCredentialDescriptor[];
+  excludeCredentials?: PublicKeyCredentialDescriptorFuture[];
   authenticatorSelection?: AuthenticatorSelectionCriteria;
   extensions?: AuthenticationExtensionsClientInputs;
   supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];

--- a/packages/typescript-types/extract-dom-types.ts
+++ b/packages/typescript-types/extract-dom-types.ts
@@ -20,6 +20,7 @@ const types = [
   'AuthenticatorAssertionResponse',
   'AttestationConveyancePreference',
   'AuthenticatorAttestationResponse',
+  'AuthenticatorTransport',
   'AuthenticationExtensionsClientInputs',
   'AuthenticationExtensionsClientOutputs',
   'AuthenticatorSelectionCriteria',

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -155,6 +155,15 @@ export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAtt
 export type AuthenticatorTransportFuture = "ble" | "internal" | "nfc" | "usb" | "cable";
 
 /**
+ * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest
+ * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
+ * know about it (sometime after 4.6.3)
+ */
+export interface PublicKeyCredentialDescriptorFuture extends Omit<PublicKeyCredentialDescriptor, 'transports'> {
+  transports?: AuthenticatorTransportFuture[];
+}
+
+/**
  * The two types of credentials as defined by bit 3 ("Backup Eligibility") in authenticator data:
  * - `"singleDevice"` credentials will never be backed up
  * - `"multiDevice"` credentials can be backed up

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -148,10 +148,11 @@ export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAtt
 }
 
 /**
- * Communication methods by which an authenticator can talk with the browser to perform WebAuthn
- * registration and authentication.
+ * A super class of TypeScript's `AuthenticatorTransport` that includes support for the latest
+ * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
+ * know about it (sometime after 4.6.3)
  */
-export type AuthenticatorTransport = "ble" | "internal" | "nfc" | "usb" | "cable";
+export type AuthenticatorTransportFuture = "ble" | "internal" | "nfc" | "usb" | "cable";
 
 /**
  * The two types of credentials as defined by bit 3 ("Backup Eligibility") in authenticator data:

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -44,7 +44,7 @@ export interface PublicKeyCredentialRequestOptionsJSON
 export interface PublicKeyCredentialDescriptorJSON
   extends Omit<PublicKeyCredentialDescriptor, 'id' | 'transports'> {
   id: Base64URLString;
-  transports?: AuthenticatorTransport[];
+  transports?: AuthenticatorTransportFuture[];
 }
 
 export interface PublicKeyCredentialUserEntityJSON
@@ -68,7 +68,7 @@ export interface RegistrationCredentialJSON
   rawId: Base64URLString;
   response: AuthenticatorAttestationResponseJSON;
   clientExtensionResults: AuthenticationExtensionsClientOutputs;
-  transports?: AuthenticatorTransport[];
+  transports?: AuthenticatorTransportFuture[];
 }
 
 /**
@@ -123,7 +123,7 @@ export type AuthenticatorDevice = {
   // Number of times this authenticator is expected to have been used
   counter: number;
   // From browser's `startRegistration()` -> RegistrationCredentialJSON.transports (API L2 and up)
-  transports?: AuthenticatorTransport[];
+  transports?: AuthenticatorTransportFuture[];
 };
 
 /**
@@ -141,7 +141,7 @@ export type Base64URLString = string;
  * Properties marked optional are not supported in all browsers.
  */
 export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAttestationResponse {
-  getTransports?: () => AuthenticatorTransport[];
+  getTransports?: () => AuthenticatorTransportFuture[];
   getAuthenticatorData?: () => ArrayBuffer;
   getPublicKey?: () => ArrayBuffer;
   getPublicKeyAlgorithm?: () => COSEAlgorithmIdentifier[];

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -42,7 +42,7 @@ export interface PublicKeyCredentialRequestOptionsJSON
 }
 
 export interface PublicKeyCredentialDescriptorJSON
-  extends Omit<PublicKeyCredentialDescriptor, 'id' | 'transports'> {
+  extends Omit<PublicKeyCredentialDescriptorFuture, 'id' | 'transports'> {
   id: Base64URLString;
   transports?: AuthenticatorTransportFuture[];
 }


### PR DESCRIPTION
I had to revisit how I tried to teach TypeScript about `"cable"` authenticator transport in #198. This time I followed the "Future" pattern I established with `AuthenticatorAttestationResponseFuture` and defined two new types:

- `AuthenticatorTransportFuture`
- `PublicKeyCredentialDescriptorFuture`

These new values replace similarly named types referenced out of TypeScript's DOM lib, including in `generateRegistrationOptions()` and `generateAuthenticationOptions()` so these'll stop erroring out on code that is otherwise fine pre-5.2.0

This should allow me to continue adapting to changes to WebAuthn faster than TypeScript's DOM lib is able to while also making it straight-forward to remove these "Future" types for their contemporary counterparts when the DOM lib gets updated.