### PR TITLE
feat/conditional-ui

### DIFF
--- a/packages/browser/src/helpers/__mocks__/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/__mocks__/browserSupportsWebAuthnAutofill.ts
@@ -1,0 +1,2 @@
+// We just need a simple mock so we can control whether this returns `true` or `false`
+export const browserSupportsWebAuthnAutofill = jest.fn();

--- a/packages/browser/src/helpers/browserSupportsConditionalMediation.ts
+++ b/packages/browser/src/helpers/browserSupportsConditionalMediation.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
+  // Just for Chrome Canary right now; the PublicKeyCredential logic below is the real API
+  // @ts-ignore
+  if (navigator.credentials.conditionalMediationSupported) {
+    return true;
+  }
+
+  return (
+    // @ts-ignore
+    PublicKeyCredential.isConditionalMediationAvailable
+    // @ts-ignore
+    && PublicKeyCredential.isConditionalMediationAvailable()
+  );
+}

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -22,7 +22,7 @@ export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
     window.PublicKeyCredential as unknown as PublicKeyCredentialFuture;
 
   return (
-    globalPublicKeyCredential.isConditionalMediationAvailable &&
+    globalPublicKeyCredential.isConditionalMediationAvailable !== undefined &&
     globalPublicKeyCredential.isConditionalMediationAvailable()
   );
 }

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { PublicKeyCredentialFuture } from '@simplewebauthn/typescript-types';
+
 /**
  * Determine if the browser supports conditional UI, so that WebAuthn credentials can
  * be shown to the user in the browser's typical password autofill popup.

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -17,10 +17,11 @@ export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
    * want. I think I'm fine with this for now since it's _supposed_ to be temporary, until TS types
    * have a chance to catch up.
    */
-  const globalPublicKeyCredential = window.PublicKeyCredential as unknown as PublicKeyCredentialFuture;
+  const globalPublicKeyCredential =
+    window.PublicKeyCredential as unknown as PublicKeyCredentialFuture;
 
   return (
-    globalPublicKeyCredential.isConditionalMediationAvailable
-    && globalPublicKeyCredential.isConditionalMediationAvailable()
+    globalPublicKeyCredential.isConditionalMediationAvailable &&
+    globalPublicKeyCredential.isConditionalMediationAvailable()
   );
 }

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * Determine if the browser supports conditional UI, so that WebAuthn credentials can
+ * be shown to the user in the browser's typical password autofill popup.
+ */
 export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
   // Just for Chrome Canary right now; the PublicKeyCredential logic below is the real API
   // @ts-ignore

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -17,7 +17,7 @@ export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
    * want. I think I'm fine with this for now since it's _supposed_ to be temporary, until TS types
    * have a chance to catch up.
    */
-  const globalPublicKeyCredential = PublicKeyCredential as unknown as PublicKeyCredentialFuture;
+  const globalPublicKeyCredential = window.PublicKeyCredential as unknown as PublicKeyCredentialFuture;
 
   return (
     globalPublicKeyCredential.isConditionalMediationAvailable

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+import { PublicKeyCredentialFuture } from '@simplewebauthn/typescript-types';
 /**
  * Determine if the browser supports conditional UI, so that WebAuthn credentials can
  * be shown to the user in the browser's typical password autofill popup.
@@ -10,10 +11,16 @@ export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
     return true;
   }
 
+  /**
+   * I don't like the `as unknown` here but there's a `declare var PublicKeyCredential` in
+   * TS' DOM lib that's making it difficult for me to just go `as PublicKeyCredentialFuture` as I
+   * want. I think I'm fine with this for now since it's _supposed_ to be temporary, until TS types
+   * have a chance to catch up.
+   */
+  const globalPublicKeyCredential = PublicKeyCredential as unknown as PublicKeyCredentialFuture;
+
   return (
-    // @ts-ignore
-    PublicKeyCredential.isConditionalMediationAvailable
-    // @ts-ignore
-    && PublicKeyCredential.isConditionalMediationAvailable()
+    globalPublicKeyCredential.isConditionalMediationAvailable
+    && globalPublicKeyCredential.isConditionalMediationAvailable()
   );
 }

--- a/packages/browser/src/helpers/webAuthnAbortService.test.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.test.ts
@@ -1,0 +1,42 @@
+import { webauthnAbortService } from './webAuthnAbortService';
+
+test('should create a new abort signal every time', () => {
+  const signal1 = webauthnAbortService.createNewAbortSignal();
+  const signal2 = webauthnAbortService.createNewAbortSignal();
+
+  expect(signal2).not.toBe(signal1);
+});
+
+test('should call abort() on existing controller when creating a new signal', () => {
+  // Populate `.controller`
+  webauthnAbortService.createNewAbortSignal();
+
+  // Spy on the existing instance of AbortController
+  const abortSpy = jest.fn();
+  // @ts-ignore
+  webauthnAbortService.controller?.abort = abortSpy;
+
+  // Generate a new signal, which should call `abort()` on the existing controller
+  webauthnAbortService.createNewAbortSignal();
+  expect(abortSpy).toHaveBeenCalledTimes(1);
+});
+
+test('should reset controller', () => {
+  // Reset the service
+  webauthnAbortService.reset();
+
+  // Populate `.controller`
+  webauthnAbortService.createNewAbortSignal();
+
+  // Spy on the existing instance of AbortController
+  const abortSpy = jest.fn();
+  // @ts-ignore
+  webauthnAbortService.controller?.abort = abortSpy;
+
+  // Reset the service
+  webauthnAbortService.reset();
+
+  // Generate a new signal, which should NOT call `abort()` because the controller was cleared
+  webauthnAbortService.createNewAbortSignal();
+  expect(abortSpy).toHaveBeenCalledTimes(0);
+});

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -1,0 +1,23 @@
+/**
+ * A way to cancel an existing WebAuthn request, for example to cancel a
+ * WebAuthn autofill authentication request for a manual authentication attempt.
+ */
+class WebAuthnAbortService {
+  private controller: AbortController | undefined;
+
+  /**
+   * Prepare an abort signal that will help support multiple auth attempts without needing to
+   * reload the page
+   */
+  createNewAbortSignal() {
+    // Abort any existing calls to navigator.credentials.get()
+    if (this.controller) {
+      this.controller.abort();
+    }
+
+    this.controller = new AbortController();
+    return this.controller.signal;
+  }
+}
+
+export const webauthnAbortService = new WebAuthnAbortService();

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -18,6 +18,10 @@ class WebAuthnAbortService {
     this.controller = new AbortController();
     return this.controller.signal;
   }
+
+  reset() {
+    this.controller = undefined;
+  }
 }
 
 export const webauthnAbortService = new WebAuthnAbortService();

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -10,7 +10,7 @@ class WebAuthnAbortService {
    * reload the page
    */
   createNewAbortSignal() {
-    // Abort any existing calls to navigator.credentials.get()
+    // Abort any existing calls to navigator.credentials.create() or navigator.credentials.get()
     if (this.controller) {
       this.controller.abort();
     }

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -2,8 +2,8 @@
  * @packageDocumentation
  * @module @simplewebauthn/browser
  */
-import startRegistration from './methods/startRegistration';
-import startAuthentication from './methods/startAuthentication';
+import { startRegistration } from './methods/startRegistration';
+import { startAuthentication } from './methods/startAuthentication';
 import { browserSupportsWebauthn } from './helpers/browserSupportsWebauthn';
 import { platformAuthenticatorIsAvailable } from './helpers/platformAuthenticatorIsAvailable';
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -6,10 +6,12 @@ import { startRegistration } from './methods/startRegistration';
 import { startAuthentication } from './methods/startAuthentication';
 import { browserSupportsWebauthn } from './helpers/browserSupportsWebauthn';
 import { platformAuthenticatorIsAvailable } from './helpers/platformAuthenticatorIsAvailable';
+import { browserSupportsWebAuthnAutofill } from './helpers/browserSupportsWebAuthnAutofill';
 
 export {
   startRegistration,
   startAuthentication,
   browserSupportsWebauthn,
   platformAuthenticatorIsAvailable,
+  browserSupportsWebAuthnAutofill,
 };

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -12,6 +12,6 @@ export {
   startRegistration,
   startAuthentication,
   browserSupportsWebauthn,
-  platformAuthenticatorIsAvailable,
   browserSupportsWebAuthnAutofill,
+  platformAuthenticatorIsAvailable,
 };

--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -10,6 +10,7 @@ import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import { WebAuthnError } from '../helpers/structs';
 import { generateCustomError } from '../helpers/__jest__/generateCustomError';
+import { webauthnAbortService } from '../helpers/webAuthnAbortService';
 
 import { startAuthentication } from './startAuthentication';
 
@@ -217,6 +218,18 @@ test('should support "cable" transport', async () => {
 
   expect(mockNavigatorGet.mock.calls[0][0].publicKey.allowCredentials[0].transports[0])
     .toEqual("cable");
+});
+
+test('should cancel an existing call when executed again', async () => {
+  const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+  // Reset the abort service so we get an accurate call count
+  // @ts-ignore
+  webauthnAbortService.controller = undefined;
+
+  // Fire off a request and immediately attempt a second one
+  startAuthentication(goodOpts1);
+  await startAuthentication(goodOpts1);
+  expect(abortSpy).toHaveBeenCalledTimes(1);
 });
 
 describe('WebAuthnError', () => {

--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -223,8 +223,7 @@ test('should support "cable" transport', async () => {
 test('should cancel an existing call when executed again', async () => {
   const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
   // Reset the abort service so we get an accurate call count
-  // @ts-ignore
-  webauthnAbortService.controller = undefined;
+  webauthnAbortService.reset();
 
   // Fire off a request and immediately attempt a second one
   startAuthentication(goodOpts1);

--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -11,7 +11,7 @@ import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import { WebAuthnError } from '../helpers/structs';
 import { generateCustomError } from '../helpers/__jest__/generateCustomError';
 
-import startAuthentication from './startAuthentication';
+import { startAuthentication } from './startAuthentication';
 
 jest.mock('../helpers/browserSupportsWebauthn');
 

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -17,12 +17,12 @@ import { webauthnAbortService } from '../helpers/webAuthnAbortService';
  * Begin authenticator "login" via WebAuthn assertion
  *
  * @param requestOptionsJSON Output from **@simplewebauthn/server**'s generateAssertionOptions(...)
- * @param supportBrowserAutofill Initialize conditional UI to enable logging in via browser
+ * @param useBrowserAutofill Initialize conditional UI to enable logging in via browser
  * autofill prompts
  */
 export async function startAuthentication(
   requestOptionsJSON: PublicKeyCredentialRequestOptionsJSON,
-  supportBrowserAutofill = false,
+  useBrowserAutofill = false,
 ): Promise<AuthenticationCredentialJSON> {
   if (!browserSupportsWebauthn()) {
     throw new Error('WebAuthn is not supported in this browser');
@@ -49,7 +49,7 @@ export async function startAuthentication(
    * Set up the page to prompt the user to select a credential for authentication via the browser's
    * input autofill mechanism.
    */
-  if (supportBrowserAutofill) {
+  if (useBrowserAutofill) {
     if (!(await browserSupportsWebAuthnAutofill())) {
       throw Error('Browser does not support WebAuthn autofill');
     }

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -14,10 +14,13 @@ import { identifyAuthenticationError } from '../helpers/identifyAuthenticationEr
 /**
  * Begin authenticator "login" via WebAuthn assertion
  *
- * @param requestOptionsJSON Output from @simplewebauthn/server's generateAssertionOptions(...)
+ * @param requestOptionsJSON Output from **@simplewebauthn/server**'s generateAssertionOptions(...)
+ * @param supportBrowserAutofill Initialize conditional UI to enable logging in via browser
+ * autofill prompts
  */
 export default async function startAuthentication(
   requestOptionsJSON: PublicKeyCredentialRequestOptionsJSON,
+  supportBrowserAutofill = false,
 ): Promise<AuthenticationCredentialJSON> {
   if (!browserSupportsWebauthn()) {
     throw new Error('WebAuthn is not supported in this browser');

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -11,6 +11,7 @@ import { browserSupportsWebauthn } from '../helpers/browserSupportsWebauthn';
 import { browserSupportsWebAuthnAutofill } from '../helpers/browserSupportsConditionalMediation';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 import { identifyAuthenticationError } from '../helpers/identifyAuthenticationError';
+import { webauthnAbortService } from '../helpers/webAuthnAbortService';
 
 /**
  * Begin authenticator "login" via WebAuthn assertion
@@ -70,6 +71,8 @@ export default async function startAuthentication(
   // Wait for the user to complete assertion
   let credential;
   try {
+    // Set up the ability to cancel this request if the user attempts another
+    options.signal = webauthnAbortService.createNewAbortSignal();
     credential = (await navigator.credentials.get(options)) as AuthenticationCredential;
   } catch (err) {
     throw identifyAuthenticationError({ error: err as Error, options });

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -82,6 +82,8 @@ export async function startAuthentication(
     credential = (await navigator.credentials.get(options)) as AuthenticationCredential;
   } catch (err) {
     throw identifyAuthenticationError({ error: err as Error, options });
+  } finally {
+    webauthnAbortService.reset();
   }
 
   if (!credential) {

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -8,7 +8,7 @@ import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import bufferToUTF8String from '../helpers/bufferToUTF8String';
 import { browserSupportsWebauthn } from '../helpers/browserSupportsWebauthn';
-import { browserSupportsWebAuthnAutofill } from '../helpers/browserSupportsConditionalMediation';
+import { browserSupportsWebAuthnAutofill } from '../helpers/browserSupportsWebAuthnAutofill';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 import { identifyAuthenticationError } from '../helpers/identifyAuthenticationError';
 import { webauthnAbortService } from '../helpers/webAuthnAbortService';

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -67,8 +67,6 @@ export async function startAuthentication(
     options.mediation = 'conditional' as CredentialMediationRequirement;
     // Conditional UI requires an empty allow list
     publicKey.allowCredentials = [];
-
-    console.log('ready for conditional UI');
   }
 
   // Finalize options

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -20,7 +20,7 @@ import { webauthnAbortService } from '../helpers/webAuthnAbortService';
  * @param supportBrowserAutofill Initialize conditional UI to enable logging in via browser
  * autofill prompts
  */
-export default async function startAuthentication(
+export async function startAuthentication(
   requestOptionsJSON: PublicKeyCredentialRequestOptionsJSON,
   supportBrowserAutofill = false,
 ): Promise<AuthenticationCredentialJSON> {

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -215,8 +215,7 @@ test('should return "cable" transport from response', async () => {
 test('should cancel an existing call when executed again', async () => {
   const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
   // Reset the abort service so we get an accurate call count
-  // @ts-ignore
-  webauthnAbortService.controller = undefined;
+  webauthnAbortService.reset();
 
   // Fire off a request and immediately attempt a second one
   startRegistration(goodOpts1);

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -8,6 +8,7 @@ import { generateCustomError } from '../helpers/__jest__/generateCustomError';
 import { browserSupportsWebauthn } from '../helpers/browserSupportsWebauthn';
 import bufferToBase64URLString from '../helpers/bufferToBase64URLString';
 import { WebAuthnError } from '../helpers/structs';
+import { webauthnAbortService } from '../helpers/webAuthnAbortService';
 
 import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 
@@ -209,6 +210,18 @@ test('should return "cable" transport from response', async () => {
   const response = await startRegistration(goodOpts1);
 
   expect(response.transports).toEqual(["cable"]);
+});
+
+test('should cancel an existing call when executed again', async () => {
+  const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+  // Reset the abort service so we get an accurate call count
+  // @ts-ignore
+  webauthnAbortService.controller = undefined;
+
+  // Fire off a request and immediately attempt a second one
+  startRegistration(goodOpts1);
+  await startRegistration(goodOpts1);
+  expect(abortSpy).toHaveBeenCalledTimes(1);
 });
 
 describe('WebAuthnError', () => {

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -11,7 +11,7 @@ import { WebAuthnError } from '../helpers/structs';
 
 import utf8StringToBuffer from '../helpers/utf8StringToBuffer';
 
-import startRegistration from './startRegistration';
+import { startRegistration } from './startRegistration';
 
 jest.mock('../helpers/browserSupportsWebauthn');
 

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -46,6 +46,8 @@ export async function startRegistration(
     credential = (await navigator.credentials.create(options)) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options });
+  } finally {
+    webauthnAbortService.reset();
   }
 
   if (!credential) {

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -35,13 +35,14 @@ export async function startRegistration(
     excludeCredentials: creationOptionsJSON.excludeCredentials.map(toPublicKeyCredentialDescriptor),
   };
 
+  // Finalize options
   const options: CredentialCreationOptions = { publicKey };
+  // Set up the ability to cancel this request if the user attempts another
+  options.signal = webauthnAbortService.createNewAbortSignal();
 
   // Wait for the user to complete attestation
   let credential;
   try {
-    // Set up the ability to cancel this request if the user attempts another
-    options.signal = webauthnAbortService.createNewAbortSignal();
     credential = (await navigator.credentials.create(options)) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options });

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -17,7 +17,7 @@ import { webauthnAbortService } from '../helpers/webAuthnAbortService';
  *
  * @param creationOptionsJSON Output from @simplewebauthn/server's generateRegistrationOptions(...)
  */
-export default async function startRegistration(
+export async function startRegistration(
   creationOptionsJSON: PublicKeyCredentialCreationOptionsJSON,
 ): Promise<RegistrationCredentialJSON> {
   if (!browserSupportsWebauthn()) {

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -10,6 +10,7 @@ import base64URLStringToBuffer from '../helpers/base64URLStringToBuffer';
 import { browserSupportsWebauthn } from '../helpers/browserSupportsWebauthn';
 import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 import { identifyRegistrationError } from '../helpers/identifyRegistrationError';
+import { webauthnAbortService } from '../helpers/webAuthnAbortService';
 
 /**
  * Begin authenticator "registration" via WebAuthn attestation
@@ -39,6 +40,8 @@ export default async function startRegistration(
   // Wait for the user to complete attestation
   let credential;
   try {
+    // Set up the ability to cancel this request if the user attempts another
+    options.signal = webauthnAbortService.createNewAbortSignal();
     credential = (await navigator.credentials.create(options)) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options });

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -168,7 +168,7 @@ export interface PublicKeyCredentialDescriptorFuture extends Omit<PublicKeyCrede
  */
 export interface PublicKeyCredentialFuture extends PublicKeyCredential {
   // See https://github.com/w3c/webauthn/issues/1745
-  isConditionalMediationAvailable(): Promise<boolean>;
+  isConditionalMediationAvailable?(): Promise<boolean>;
 }
 
 /**

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -164,6 +164,14 @@ export interface PublicKeyCredentialDescriptorFuture extends Omit<PublicKeyCrede
 }
 
 /**
+ * A super class of TypeScript's `PublicKeyCredential` that knows about upcoming WebAuthn methods
+ */
+export interface PublicKeyCredentialFuture extends PublicKeyCredential {
+  // See https://github.com/w3c/webauthn/issues/1745
+  isConditionalMediationAvailable(): Promise<boolean>;
+}
+
+/**
  * The two types of credentials as defined by bit 3 ("Backup Eligibility") in authenticator data:
  * - `"singleDevice"` credentials will never be backed up
  * - `"multiDevice"` credentials can be backed up


### PR DESCRIPTION
This PR adds support for upcoming browsers' [conditional UI](https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI) capability to **@simplewebauthn/browser**'s `startAuthentication()`.

To use it, pass in `true` for the new second `useBrowserAutofill` positional argument to `startAuthentication()`, then specify Promise resolution (or rejection) logic to handle the user possibly, eventually choosing a WebAuthn credential via the browser's autofill mechanism:

```html
<head>
  <!-- ... -->
  <script>
    const { startAuthentication } = SimpleWebAuthnBrowser;

    fetch('/generate-authentication-options')
      .then((options) => {
        startAuthentication(options, true)
          .then(authResp => sendToServerForVerificationAndLogin)
          .catch(err => handleError);
      });
  </script>
</head>
```

**Guidance from platform vendors indicates that it is important to initialize WebAuthn's Conditional UI experience as soon as possible.** Placing this logic in `<head>` should give browsers enough time to query authenticators for any discoverable credentials to display to the user. It may also work to delay painting UI For N milliseconds to achieve the same thing in something like a single-page app that would trigger this experience some time after page load. It's still early days for this capability so ymmv.

A new asynchronous `browserSupportsWebAuthnAutofill()` helper is also being added in this PR. This method can be used independently of the call that's made in `startAuthentication()` when initializing browser autofill support.

Existing authentication UI and logic should not need to be refactored. This new "pending" WebAuthn request will be automatically cancelled on a subsequent execution of `startAuthentication()` in, say, an existing click handler that triggers the browser's typical "modal" WebAuthn experience.

Conditional UI is still a nascent capability, but this method should be pretty reliable since the API is largely settled. This new logic has been successfully tested in both **Chrome Canary**[1][2] and **Safari in the macOS Ventura beta**.

## Screenshots

Chrome Canary:

![Screen Shot 2022-06-17 at 4 18 17 PM](https://user-images.githubusercontent.com/5166470/177175097-c368632a-b27e-46f7-8013-117e2c75675b.png)

Safari in the macOS Ventura beta:

![FVfczGlUsAI7kYb](https://user-images.githubusercontent.com/5166470/177175343-5534ca3b-7449-48c7-a5bd-d78fe9f9c232.jpg)

Addresses #209.

------

**[1]** The following flag must be specified when launching Chrome Canary to enable Conditional UI:

```
open -a /Applications/Google\ Chrome\ Canary.app --args --enable-features=WebAuthenticationConditionalUI
```

**[2]** I've been informed there's a race condition deep within Chrome Canary that sometimes prevents the autofill from populating with WebAuthn credentials. If they aren't showing up just keep refreshing and eventually they'll appear. This is a temporary issue and will definitely be resolved before Chrome's Conditional UI support lands in Chrome Stable.