### PR TITLE
feat/authenticator-attachment

### DIFF
--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -287,6 +287,23 @@ test('should throw error if no acceptable <input> is found', async () => {
   rejected.toThrow(/no <input>/i);
 });
 
+test('should return authenticatorAttachment if present', async () => {
+  // Mock extension return values from authenticator
+  mockNavigatorGet.mockImplementation((): Promise<any> => {
+    return new Promise(resolve => {
+      resolve({
+        response: {},
+        getClientExtensionResults: () => {},
+        authenticatorAttachment: 'cross-platform',
+      });
+    });
+  });
+
+  const response = await startAuthentication(goodOpts1);
+
+  expect(response.authenticatorAttachment).toEqual('cross-platform');
+});
+
 describe('WebAuthnError', () => {
   describe('AbortError', () => {
     const AbortError = generateCustomError('AbortError');

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -107,5 +107,6 @@ export async function startAuthentication(
     },
     type,
     clientExtensionResults: credential.getClientExtensionResults(),
+    authenticatorAttachment: credential.authenticatorAttachment,
   };
 }

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -223,6 +223,23 @@ test('should cancel an existing call when executed again', async () => {
   expect(abortSpy).toHaveBeenCalledTimes(1);
 });
 
+test('should return authenticatorAttachment if present', async () => {
+  // Mock extension return values from authenticator
+  mockNavigatorCreate.mockImplementation((): Promise<any> => {
+    return new Promise(resolve => {
+      resolve({
+        response: {},
+        getClientExtensionResults: () => {},
+        authenticatorAttachment: 'cross-platform',
+      });
+    });
+  });
+
+  const response = await startRegistration(goodOpts1);
+
+  expect(response.authenticatorAttachment).toEqual('cross-platform');
+});
+
 describe('WebAuthnError', () => {
   describe('AbortError', () => {
     const AbortError = generateCustomError('AbortError');

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -66,6 +66,7 @@ export async function startRegistration(
     },
     type,
     clientExtensionResults: credential.getClientExtensionResults(),
+    authenticatorAttachment: credential.authenticatorAttachment,
   };
 
   /**

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -14,6 +14,7 @@ import type {
   PublicKeyCredentialUserEntity,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
+  AuthenticatorAttachment,
 } from './dom';
 
 export * from './dom';
@@ -169,6 +170,8 @@ export interface PublicKeyCredentialDescriptorFuture extends Omit<PublicKeyCrede
 export interface PublicKeyCredentialFuture extends PublicKeyCredential {
   // See https://github.com/w3c/webauthn/issues/1745
   isConditionalMediationAvailable?(): Promise<boolean>;
+  // See https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment
+  authenticatorAttachment?: AuthenticatorAttachment;
 }
 
 /**

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -56,7 +56,7 @@ export interface PublicKeyCredentialUserEntityJSON
 /**
  * The value returned from navigator.credentials.create()
  */
-export interface RegistrationCredential extends PublicKeyCredential {
+export interface RegistrationCredential extends PublicKeyCredentialFuture {
   response: AuthenticatorAttestationResponseFuture;
 }
 
@@ -75,7 +75,7 @@ export interface RegistrationCredentialJSON
 /**
  * The value returned from navigator.credentials.get()
  */
-export interface AuthenticationCredential extends PublicKeyCredential {
+export interface AuthenticationCredential extends PublicKeyCredentialFuture {
   response: AuthenticatorAssertionResponse;
 }
 


### PR DESCRIPTION
This PR adds a new `authenticatorAttachment` property to the values returned from **@simplewebauthn/browser**'s `startRegistration()` and `startAuthentication()` methods.

This value will communicate whether registration or authentication took place via a `"cross-platform"` or `"platform"` authenticator:

![Screen Shot 2022-07-04 at 8 56 36 AM](https://user-images.githubusercontent.com/5166470/177188523-0afc68dc-012a-4a11-bee7-84a2a489f5ad.png)

**This property is part of the WebAuthn L3 spec draft** and is subject to change. It has been observed in **Chrome Stable Version 103.0.5060.53**, though, and future evergreen browsers are sure to start reporting it as well.

Fixes #220.