### PR TITLE
feat/transports-hybrid

### DIFF
--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -153,7 +153,7 @@ export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAtt
  * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
  * know about it (sometime after 4.6.3)
  */
-export type AuthenticatorTransportFuture = "ble" | "internal" | "nfc" | "usb" | "cable";
+export type AuthenticatorTransportFuture = "ble" | "internal" | "nfc" | "usb" | "cable" | "hybrid";
 
 /**
  * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest


### PR DESCRIPTION
This PR adds a new `"hybrid"` transport to `AuthenticatorTransportFuture`. This new transport will soon replace the old `"cable"` transport across all browsers (as has been agreed upon at the FIDO TWG level).

`"cable"` is being left in for backwards compatibility with existing credentials.