### PR TITLE
Fix credential ID comparison in example

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -182,7 +182,7 @@ app.post('/verify-registration', async (req, res) => {
   if (verified && registrationInfo) {
     const { credentialPublicKey, credentialID, counter } = registrationInfo;
 
-    const existingDevice = user.devices.find(device => device.credentialID === credentialID);
+    const existingDevice = user.devices.find(device => device.credentialID.equals(credentialID));
 
     if (!existingDevice) {
       /**


### PR DESCRIPTION
This PR fixes the `credentialID` comparison used to identify if the device/authenticator the user tries to register already exists.
Since the `credentialID` is of type `Buffer` it is not possible to use `===` as this would always return `false`, instead `Buffer.equals` has to be used which checks if the values have exactly the same bytes.