### PR TITLE
Added "type":"module" to package.json

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplewebauthn/browser",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "SimpleWebAuthn for Browsers",
   "main": "dist/bundle/index.js",
   "unpkg": "dist/bundle/index.umd.min.js",
@@ -37,5 +37,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-version-injector": "^1.3.3"
   },
+  "type": "module",
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplewebauthn/browser",
-  "version": "5.3.1",
+  "version": "5.3.0",
   "description": "SimpleWebAuthn for Browsers",
   "main": "dist/bundle/index.js",
   "unpkg": "dist/bundle/index.umd.min.js",


### PR DESCRIPTION
Thanks for this wonderful package!

I am using vite 3.0 to build my projects and vite complains that this package appears to be an ESM module, but does not state so in the package.json

vite 3.0:
```
@simplewebauthn/browser doesn't appear to 
be written in CJS, but also doesn't appear to 
be a valid ES module
```

Adding the "type":"module" in package.json fixes that.