### PR TITLE
fix/optimize-convert-cert-buffer-to-pem

### DIFF
--- a/packages/server/src/helpers/convertCertBufferToPEM.ts
+++ b/packages/server/src/helpers/convertCertBufferToPEM.ts
@@ -5,14 +5,16 @@ import type { Base64URLString } from '@simplewebauthn/typescript-types';
  * Convert buffer to an OpenSSL-compatible PEM text format.
  */
 export function convertCertBufferToPEM(certBuffer: Buffer | Base64URLString): string {
-  let buffer: Buffer;
-  if (typeof certBuffer === 'string') {
-    buffer = base64url.toBuffer(certBuffer);
-  } else {
-    buffer = certBuffer;
-  }
+  let b64cert: string;
 
-  const b64cert = buffer.toString('base64');
+  /**
+   * Get certBuffer to a base64 representation
+   */
+  if (typeof certBuffer === 'string') {
+    b64cert = base64url.toBase64(certBuffer);
+  } else {
+    b64cert = certBuffer.toString('base64');
+  }
 
   let PEMKey = '';
   for (let i = 0; i < Math.ceil(b64cert.length / 64); i += 1) {


### PR DESCRIPTION
I peeked at `convertCertBufferToPEM()` for the first time in a while, and it felt silly to convert from **base64url** -> **Buffer** -> **base64**, when I already had a **base64url** string that was just a few string replacements away from becoming that **base64** string.

Now it'll keep the base64url a string and do the massaging to get to a base64 string, and only resort to `.toString('base64')` when the method receives a `Buffer`.