### PR TITLE
feat/fido-conformance-optional-up

### DIFF
--- a/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
@@ -372,6 +372,115 @@ test('should return credential backup info', async () => {
   expect(verification.authenticationInfo?.credentialBackedUp).toEqual(false);
 });
 
+test('[FIDO Conformance] should verify if user verification is required and user was verified but not present', () => {
+  const actualData = esmParseAuthenticatorData.parseAuthenticatorData(
+    base64url.toBuffer(assertionResponse.response.authenticatorData),
+  );
+
+  mockParseAuthData.mockReturnValue({
+    ...actualData,
+    flags: {
+      up: false,
+      uv: true,
+    },
+  });
+
+  const verification = verifyAuthenticationResponse({
+    credential: assertionResponse,
+    expectedChallenge: assertionChallenge,
+    expectedOrigin: assertionOrigin,
+    expectedRPID: 'dev.dontneeda.pw',
+    authenticator: authenticator,
+    advancedFIDOConfig: {
+      userVerification: 'required',
+    }
+  });
+
+  expect(verification.verified).toEqual(true);
+});
+
+test('[FIDO Conformance] should verify if user verification is preferred and user was not verified or present', () => {
+  const actualData = esmParseAuthenticatorData.parseAuthenticatorData(
+    base64url.toBuffer(assertionResponse.response.authenticatorData),
+  );
+
+  mockParseAuthData.mockReturnValue({
+    ...actualData,
+    flags: {
+      up: false,
+      uv: false,
+    },
+  });
+
+  const verification = verifyAuthenticationResponse({
+    credential: assertionResponse,
+    expectedChallenge: assertionChallenge,
+    expectedOrigin: assertionOrigin,
+    expectedRPID: 'dev.dontneeda.pw',
+    authenticator: authenticator,
+    requireUserVerification: false,
+    advancedFIDOConfig: {
+      userVerification: 'preferred',
+    },
+  });
+
+  expect(verification.verified).toEqual(true);
+});
+
+test('[FIDO Conformance] should verify if user verification is discouraged and user was verified but not present', () => {
+  const actualData = esmParseAuthenticatorData.parseAuthenticatorData(
+    base64url.toBuffer(assertionResponse.response.authenticatorData),
+  );
+
+  mockParseAuthData.mockReturnValue({
+    ...actualData,
+    flags: {
+      up: false,
+      uv: true,
+    },
+  });
+
+  const verification = verifyAuthenticationResponse({
+    credential: assertionResponse,
+    expectedChallenge: assertionChallenge,
+    expectedOrigin: assertionOrigin,
+    expectedRPID: 'dev.dontneeda.pw',
+    authenticator: authenticator,
+    advancedFIDOConfig: {
+      userVerification: 'discouraged',
+    },
+  });
+
+  expect(verification.verified).toEqual(true);
+});
+
+test('[FIDO Conformance] should verify if user verification is discouraged and user was not verified or present', () => {
+  const actualData = esmParseAuthenticatorData.parseAuthenticatorData(
+    base64url.toBuffer(assertionResponse.response.authenticatorData),
+  );
+
+  mockParseAuthData.mockReturnValue({
+    ...actualData,
+    flags: {
+      up: false,
+      uv: false,
+    },
+  });
+
+  const verification = verifyAuthenticationResponse({
+    credential: assertionResponse,
+    expectedChallenge: assertionChallenge,
+    expectedOrigin: assertionOrigin,
+    expectedRPID: 'dev.dontneeda.pw',
+    authenticator: authenticator,
+    advancedFIDOConfig: {
+      userVerification: 'discouraged',
+    },
+  });
+
+  expect(verification.verified).toEqual(true);
+});
+
 /**
  * Assertion examples below
  */


### PR DESCRIPTION
This PR re-introduces support for FIDO Conformance-based rules for the `up` and `uv` authenticator data flags.

To leverage these rules (as might be the case for RP's seeking FIDO certification), update your calls to `verifyAuthenticationResponse()` to **replace** `requireUserVerification` with the new `advancedFIDOConfig.userVerification` option:

**Before:**
```ts
const verification = verifyAuthenticationResponse({
  // ...
  requireUserVerification: true
});
```

**After**
```ts
const verification = verifyAuthenticationResponse({
  // ...
  advancedFIDOConfig: {
    // UserVerificationRequirement: 'required' | 'preferred' | 'discouraged'
    userVerification: 'required',
  },
});
```

Setting `advancedFIDOConfig.userVerification` to `'required'` will only require the `uv` flag to be true; `up` flag may be `false`. Setting it to `'preferred'` or `'discouraged'` will allow both `up` and `uv` to be `false` during verification.

This should resolve #253.