### PR TITLE
Fix/improve resident key registration options

### DIFF
--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -49,6 +49,7 @@ test('should generate credential request options suitable for sending via JSON',
     excludeCredentials: [],
     authenticatorSelection: {
       requireResidentKey: false,
+      residentKey: 'discouraged',
       userVerification: 'preferred',
     },
   });
@@ -120,6 +121,7 @@ test('should set authenticatorSelection if specified', () => {
   expect(options.authenticatorSelection).toEqual({
     authenticatorAttachment: 'cross-platform',
     requireResidentKey: false,
+    residentKey: 'discouraged',
     userVerification: 'preferred',
   });
 });
@@ -165,4 +167,91 @@ test('should use custom supported algorithm IDs as-is when provided', () => {
     { alg: -8, type: 'public-key' },
     { alg: -65535, type: 'public-key' },
   ]);
+});
+
+test('should require resident key if residentKey option is absent but requireResidentKey is set to true', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorSelection: {
+      requireResidentKey: true,
+    }
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(true);
+  expect(options.authenticatorSelection?.residentKey).toEqual('required');
+});
+
+test('should discourage resident key if residentKey option is absent but requireResidentKey is set to false', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorSelection: {
+      requireResidentKey: false,
+    }
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
+  expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
+});
+
+test('should discourage resident key if both residentKey and requireResidentKey options are absent', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
+  expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
+});
+
+test('should set requireResidentKey to true if residentKey if set to required', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorSelection: {
+      residentKey: 'required',
+    },
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(true);
+  expect(options.authenticatorSelection?.residentKey).toEqual('required');
+});
+
+test('should set requireResidentKey to false if residentKey if set to preferred', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorSelection: {
+      residentKey: 'preferred',
+    },
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
+  expect(options.authenticatorSelection?.residentKey).toEqual('preferred');
+});
+
+test('should set requireResidentKey to false if residentKey if set to discouraged', () => {
+  const options = generateRegistrationOptions({
+    rpID: 'not.real',
+    rpName: 'SimpleWebAuthn',
+    userID: '1234',
+    userName: 'usernameHere',
+    authenticatorSelection: {
+      residentKey: 'discouraged',
+    },
+  });
+
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
+  expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
 });

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -49,7 +49,6 @@ test('should generate credential request options suitable for sending via JSON',
     excludeCredentials: [],
     authenticatorSelection: {
       requireResidentKey: false,
-      residentKey: 'discouraged',
       userVerification: 'preferred',
     },
   });
@@ -121,7 +120,6 @@ test('should set authenticatorSelection if specified', () => {
   expect(options.authenticatorSelection).toEqual({
     authenticatorAttachment: 'cross-platform',
     requireResidentKey: false,
-    residentKey: 'discouraged',
     userVerification: 'preferred',
   });
 });
@@ -196,10 +194,10 @@ test('should discourage resident key if residentKey option is absent but require
   });
 
   expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
-  expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
+  expect(options.authenticatorSelection?.residentKey).toBeUndefined();
 });
 
-test('should discourage resident key if both residentKey and requireResidentKey options are absent', () => {
+test('should not set resident key if both residentKey and requireResidentKey options are absent', () => {
   const options = generateRegistrationOptions({
     rpID: 'not.real',
     rpName: 'SimpleWebAuthn',
@@ -208,7 +206,7 @@ test('should discourage resident key if both residentKey and requireResidentKey 
   });
 
   expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
-  expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
+  expect(options.authenticatorSelection?.residentKey).toBeUndefined();
 });
 
 test('should set requireResidentKey to true if residentKey if set to required', () => {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -120,15 +120,30 @@ export function generateRegistrationOptions(
   }));
 
   /**
-   * "Relying Parties SHOULD set [requireResidentKey] to true if, and only if, residentKey is set
-   * to "required""
    *
-   * See https://www.w3.org/TR/webauthn-2/#dom-authenticatorselectioncriteria-requireresidentkey
    */
-  if (authenticatorSelection.residentKey === 'required') {
-    authenticatorSelection.requireResidentKey = true;
+  if (authenticatorSelection.residentKey === undefined) {
+    /**
+     * `residentKey`: "If no value is given then the effective value is `required` if
+     * requireResidentKey is true or `discouraged` if it is false or absent."
+     *
+     * See https://www.w3.org/TR/webauthn-2/#dom-authenticatorselectioncriteria-residentkey
+     */
+    if (authenticatorSelection.requireResidentKey) {
+      authenticatorSelection.residentKey = 'required';
+    } else {
+      authenticatorSelection.residentKey = 'discouraged';
+    }
   } else {
-    authenticatorSelection.requireResidentKey = false;
+    /**
+     * `requireResidentKey`: "Relying Parties SHOULD set it to true if, and only if, residentKey is
+     * set to "required""
+     *
+     * Spec says this property defaults to `false` so we should still be okay to assign `false` too
+     *
+     * See https://www.w3.org/TR/webauthn-2/#dom-authenticatorselectioncriteria-requireresidentkey
+     */
+    authenticatorSelection.requireResidentKey = authenticatorSelection.residentKey === 'required';
   }
 
   return {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -120,7 +120,8 @@ export function generateRegistrationOptions(
   }));
 
   /**
-   *
+   * Capture some of the nuances of how `residentKey` and `requireResidentKey` how either is set
+   * depending on when either is defined in the options
    */
   if (authenticatorSelection.residentKey === undefined) {
     /**
@@ -132,7 +133,11 @@ export function generateRegistrationOptions(
     if (authenticatorSelection.requireResidentKey) {
       authenticatorSelection.residentKey = 'required';
     } else {
-      authenticatorSelection.residentKey = 'discouraged';
+      /**
+       * FIDO Conformance v1.7.2 fails the first test if we do this, even though this is
+       * technically compatible with the WebAuthn L2 spec...
+       */
+      // authenticatorSelection.residentKey = 'discouraged';
     }
   } else {
     /**


### PR DESCRIPTION
This PR adjusts logic related to how the old `requireResidentKey` and new `residentKey` authentication selection options influence what either is set to in the output from `generateRegistrationOptions()`:

- If `residentKey` is absent, then it will be set to `"required"` if `requireResidentKey` is present and `true`
- Otherwise if `requireResidentKey` is absent then it will be set to whether or not `residentKey` is set to `"required"`

This should help implementers targeting L1 of the spec generate options that will trigger discoverable credential creation in environments targeting L2 of the spec as well.

Fixes #255 