### PR TITLE
feat/prefer-ed25519

### DIFF
--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -34,8 +34,8 @@ test('should generate credential request options suitable for sending via JSON',
       displayName: userName,
     },
     pubKeyCredParams: [
-      { alg: -7, type: 'public-key' },
       { alg: -8, type: 'public-key' },
+      { alg: -7, type: 'public-key' },
       { alg: -36, type: 'public-key' },
       { alg: -37, type: 'public-key' },
       { alg: -38, type: 'public-key' },
@@ -252,4 +252,16 @@ test('should set requireResidentKey to false if residentKey if set to discourage
 
   expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
   expect(options.authenticatorSelection?.residentKey).toEqual('discouraged');
+});
+
+test('should prefer Ed25519 in pubKeyCredParams', () => {
+  const options = generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userID: '1234',
+    userName: 'usernameHere',
+  });
+
+  expect(options.pubKeyCredParams[0].alg).toEqual(-8);
 });

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -32,10 +32,10 @@ export type GenerateRegistrationOptionsOpts = {
  * and https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  */
 export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
+  // EdDSA (In first position to encourage authenticators to use this over ES256)
+  -8,
   // ECDSA w/ SHA-256
   -7,
-  // EdDSA
-  -8,
   // ECDSA w/ SHA-512
   -36,
   // RSASSA-PSS w/ SHA-256


### PR DESCRIPTION
Setting `-8` as the first algorithm in `pubKeyCredParams` encourages authenticators that support the EdDSA algorithm to use Ed25519 when generating their keypair. 

An amusing read on benefits of Ed25519 over other algorithms and curves: https://soatok.blog/2022/05/19/guidance-for-choosing-an-elliptic-curve-signature-algorithm-in-2022/

Fixes #260 