### PR TITLE
feat/authentication-uv-flag-return

### DIFF
--- a/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
@@ -432,3 +432,16 @@ const authenticatorFirstTimeUsed: AuthenticatorDevice = {
   ),
   counter: 0,
 };
+
+test('should return user verified flag after successful auth', async () => {
+  const verification = await verifyAuthenticationResponse({
+    credential: assertionResponse,
+    expectedChallenge: assertionChallenge,
+    expectedOrigin: assertionOrigin,
+    expectedRPID: 'dev.dontneeda.pw',
+    authenticator: authenticator,
+  });
+
+  expect(verification.authenticationInfo?.userVerified).toBeDefined();
+  expect(verification.authenticationInfo?.userVerified).toEqual(false);
+});

--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -219,6 +219,7 @@ export async function verifyAuthenticationResponse(
     authenticationInfo: {
       newCounter: counter,
       credentialID: authenticator.credentialID,
+      userVerified: flags.uv,
       credentialDeviceType,
       credentialBackedUp,
       authenticatorExtensionResults: extensionsData,
@@ -251,6 +252,7 @@ export type VerifiedAuthenticationResponse = {
   authenticationInfo: {
     credentialID: Buffer;
     newCounter: number;
+    userVerified: boolean;
     credentialDeviceType: CredentialDeviceType;
     credentialBackedUp: boolean;
     authenticatorExtensionResults?: AuthenticationExtensionsAuthenticatorOutputs;

--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -210,7 +210,7 @@ export async function verifyAuthenticationResponse(
 
   const { credentialDeviceType, credentialBackedUp } = parseBackupFlags(flags);
 
-  const toReturn = {
+  const toReturn: VerifiedAuthenticationResponse = {
     verified: await verifySignature({
       signature,
       signatureBase,


### PR DESCRIPTION
This PR adds the `userVerified` property to `authenticationInfo` returned from a successful run of `verifyAuthenticationResponse()`, to match the same info returned from `verifyRegistrationResponse()`. This can be useful to RP's that don't require user verification but are still interested in whether the authenticator is capable of it.