### PR TITLE
fix/webauthn-abort-controller-race-condition

### DIFF
--- a/packages/browser/src/helpers/webAuthnAbortService.test.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.test.ts
@@ -20,23 +20,3 @@ test('should call abort() on existing controller when creating a new signal', ()
   webauthnAbortService.createNewAbortSignal();
   expect(abortSpy).toHaveBeenCalledTimes(1);
 });
-
-test('should reset controller', () => {
-  // Reset the service
-  webauthnAbortService.reset();
-
-  // Populate `.controller`
-  webauthnAbortService.createNewAbortSignal();
-
-  // Spy on the existing instance of AbortController
-  const abortSpy = jest.fn();
-  // @ts-ignore
-  webauthnAbortService.controller?.abort = abortSpy;
-
-  // Reset the service
-  webauthnAbortService.reset();
-
-  // Generate a new signal, which should NOT call `abort()` because the controller was cleared
-  webauthnAbortService.createNewAbortSignal();
-  expect(abortSpy).toHaveBeenCalledTimes(0);
-});

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -18,10 +18,6 @@ class WebAuthnAbortService {
     this.controller = new AbortController();
     return this.controller.signal;
   }
-
-  reset() {
-    this.controller = undefined;
-  }
 }
 
 export const webauthnAbortService = new WebAuthnAbortService();

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -12,7 +12,7 @@ class WebAuthnAbortService {
   createNewAbortSignal() {
     // Abort any existing calls to navigator.credentials.create() or navigator.credentials.get()
     if (this.controller) {
-      this.controller.abort();
+      this.controller.abort('Cancelling existing WebAuthn API call for new one');
     }
 
     this.controller = new AbortController();

--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -60,6 +60,10 @@ beforeEach(() => {
 
   mockSupportsWebAuthn.mockReturnValue(true);
   mockSupportsAutofill.mockResolvedValue(true);
+
+  // Reset the abort service so we get an accurate call count
+  // @ts-ignore
+  webauthnAbortService.controller = undefined;
 });
 
 afterEach(() => {
@@ -228,8 +232,6 @@ test('should support "cable" transport', async () => {
 
 test('should cancel an existing call when executed again', async () => {
   const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
-  // Reset the abort service so we get an accurate call count
-  webauthnAbortService.reset();
 
   // Fire off a request and immediately attempt a second one
   startAuthentication(goodOpts1);

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -80,8 +80,6 @@ export async function startAuthentication(
     credential = (await navigator.credentials.get(options)) as AuthenticationCredential;
   } catch (err) {
     throw identifyAuthenticationError({ error: err as Error, options });
-  } finally {
-    webauthnAbortService.reset();
   }
 
   if (!credential) {

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -59,6 +59,10 @@ beforeEach(() => {
   });
 
   mockSupportsWebauthn.mockReturnValue(true);
+
+  // Reset the abort service so we get an accurate call count
+  // @ts-ignore
+  webauthnAbortService.controller = undefined;
 });
 
 afterEach(() => {
@@ -215,8 +219,6 @@ test('should return "cable" transport from response', async () => {
 
 test('should cancel an existing call when executed again', async () => {
   const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
-  // Reset the abort service so we get an accurate call count
-  webauthnAbortService.reset();
 
   // Fire off a request and immediately attempt a second one
   startRegistration(goodOpts1);

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -46,8 +46,6 @@ export async function startRegistration(
     credential = (await navigator.credentials.create(options)) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options });
-  } finally {
-    webauthnAbortService.reset();
   }
 
   if (!credential) {


### PR DESCRIPTION
This PR attempts to remove a race condition from browser's WebAuthnAbortService. It was discovered that multiple invocations of `startAuthentication()` in a row (especially in a SPA using clientside routing), particularly when conditional UI is started, could lead to `WebAuthnAbortService.reset()` being called early which would fail a subsequent call to `startAuthentication()` with a `DOMException` and "a request is already pending."

I determined that this was due to the call to `this.controller.abort()` not actually aborting the `navigator.credentials.get()` synchronously. We can't `await` an `AbortController.abort()` to wait for the `navigator.credentials.get()` to be aborted; we can only abort and cross our fingers that we don't call `startAuthentication()` until the WebAuthn API call actually terminates in response to the abort signal.

This can lead to `.reset()` being called by the first `startAuthentication()`'s `try / catch / finally` _after_ a subsequent call to `webauthnAbortService.createNewAbortSignal()`, which expects `this.controller` to be populated with the new controller but ends up becoming `undefined` when the `.reset()` gets called after the first controller calls `.abort()`. The second call to `startAuthentication()` can no longer be aborted, and a third call will error out because the second WebAuthn API call is indeed still pending.

See https://github.com/MasterKale/SimpleWebAuthn/issues/273#issuecomment-1257519264, I included some logging output that might make it clearer if the above description is insufficient.

The fix is to remove the `reset()` method from `WebAuthnAbortService`. In testing I observed no issues with possibly repeatedly calling `.abort()` on an already-aborted controller. Thus we can leave the service's `this.controller` populated between calls to `createNewAbortSignal()` and forget about trying to tame a race condition.

Fixes #273.

## Demonstration

https://user-images.githubusercontent.com/5166470/192686991-10ea47d0-8aa9-4f1f-bb52-03d6ee3326a0.mov



