### PR TITLE
Stop hoisting deps

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,5 +25,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i
-    - run: npm run bootstrap
+    - run: npm run bootstrap:ci
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ example/*.key
 example/*.crt
 example/fido-conformance-mds/*
 !example/fido-conformance-mds/.gitkeep
-src/*/package-lock.json
+packages/*/package-lock.json
 packages/typescript-types/src/dom.ts

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "bootstrap:ci": "lerna bootstrap --hoist",
+    "clean": "lerna clean -y && rm ./packages/**/package-lock.json",
     "lint": "prettier --write packages/**/src/**/*.ts example/**/*.ts && eslint --fix packages/**/src/**/*.ts example/**/*.ts",
     "docs": "npm run bootstrap && typedoc --tsconfig tsconfigdoc.json",
     "test": "lerna run test",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bootstrap:ci": "lerna bootstrap --hoist",
     "clean": "lerna clean -y && rm ./packages/**/package-lock.json",
     "lint": "prettier --write packages/**/src/**/*.ts example/**/*.ts && eslint --fix packages/**/src/**/*.ts example/**/*.ts",
-    "docs": "npm run bootstrap && typedoc --tsconfig tsconfigdoc.json",
+    "docs": "npm run bootstrap:ci && typedoc --tsconfig tsconfigdoc.json",
     "test": "lerna run test",
     "build:types": "lerna run build --scope=@simplewebauthn/typescript-types",
     "build:testing": "lerna run build --scope=@simplewebauthn/testing",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "simplewebauthn-monorepo",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap --hoist",
+    "bootstrap": "lerna bootstrap",
+    "bootstrap:ci": "lerna bootstrap --hoist",
     "lint": "prettier --write packages/**/src/**/*.ts example/**/*.ts && eslint --fix packages/**/src/**/*.ts example/**/*.ts",
     "docs": "npm run bootstrap && typedoc --tsconfig tsconfigdoc.json",
     "test": "lerna run test",


### PR DESCRIPTION
A couple of things lately have confused me about this monorepo's Lerna setup:

1. Why weren't **package-lock.json** files within **packages/** ignored? (https://github.com/MasterKale/SimpleWebAuthn/pull/267#pullrequestreview-1114650433)
2. Why has Lerna been eager to start including `"devDependencies"` in **package.json** files within **packages/** as `"dependencies"` in the root **package-lock.json**? (https://github.com/MasterKale/SimpleWebAuthn/issues/273#issuecomment-1260579047)

Something seems to have changed in Lerna since I initially added the `--hoist` option back in #213, or I've misunderstood this whole time. In any case this PR should help synchronize how I _want_ monorepo dependencies to be managed with how they are actually managed by Lerna.