### PR TITLE
Refine publish flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bootstrap": "lerna bootstrap",
     "bootstrap:ci": "lerna bootstrap --hoist",
     "clean": "lerna clean -y && rm ./packages/**/package-lock.json",
+    "publish": "lerna bootstrap && rm ./packages/**/package-lock.json && lerna publish",
     "lint": "prettier --write packages/**/src/**/*.ts example/**/*.ts && eslint --fix packages/**/src/**/*.ts example/**/*.ts",
     "docs": "npm run bootstrap:ci && typedoc --tsconfig tsconfigdoc.json",
     "test": "lerna run test",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
-    "@simplewebauthn/typescript-types": "^6.2.1",
+    "@simplewebauthn/typescript-types": "*",
     "rollup": "^2.52.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-version-injector": "^1.3.3"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,7 +51,6 @@
     "@peculiar/asn1-android": "^2.1.7",
     "@peculiar/asn1-schema": "^2.1.7",
     "@peculiar/asn1-x509": "^2.1.7",
-    "@simplewebauthn/typescript-types": "^6.2.1",
     "base64url": "^3.0.1",
     "cbor": "^5.1.0",
     "debug": "^4.3.2",
@@ -61,6 +60,7 @@
   },
   "gitHead": "33ccf8c6c9add811c87d3089e24156c2342b3498",
   "devDependencies": {
+    "@simplewebauthn/typescript-types": "*",
     "@types/cbor": "^5.0.1",
     "@types/debug": "^4.1.7",
     "@types/jsrsasign": "^8.0.13",


### PR DESCRIPTION
This PR tweaks package configs a bit, but more importantly adds a new `"publish"` `npm` script to address #278.

For future reference the `"publish"` script does the following:

1. A non-hoisting bootstrap, which creates package-lock.json files in each package
2. Removes these "leaf" package-lock.json files
3. Runs Lerna's publish command

Step 2 is required because otherwise Step 3 errors out on a `git add` command that attempts to add ignored files (in this case the leaf lock files.) Issue #278 has more context and error output.