### PR TITLE
fix/295-remove-old-chrome-condtional-ui

### DIFF
--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -6,12 +6,6 @@ import { PublicKeyCredentialFuture } from '@simplewebauthn/typescript-types';
  * be shown to the user in the browser's typical password autofill popup.
  */
 export async function browserSupportsWebAuthnAutofill(): Promise<boolean> {
-  // Just for Chrome Canary right now; the PublicKeyCredential logic below is the real API
-  // @ts-ignore
-  if (navigator.credentials.conditionalMediationSupported) {
-    return true;
-  }
-
   /**
    * I don't like the `as unknown` here but there's a `declare var PublicKeyCredential` in
    * TS' DOM lib that's making it difficult for me to just go `as PublicKeyCredentialFuture` as I


### PR DESCRIPTION
This PR removes support for Chrome Canary's old method of querying for Conditional UI support. As of Chrome Canary 109, Chrome will support use of the official WebAuthn API for checking for support:

![Screenshot 2022-11-03 at 8 44 30 PM](https://user-images.githubusercontent.com/5166470/199881061-46bdcd1c-e476-47ed-8898-31063244a88d.png)

Fixed #295.