### PR TITLE
feat/passwordless-defaults

### DIFF
--- a/packages/server/src/authentication/generateAuthenticationOptions.test.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.test.ts
@@ -41,6 +41,7 @@ test('should generate credential request options suitable for sending via JSON',
       },
     ],
     timeout: 1,
+    userVerification: 'preferred',
   });
 });
 
@@ -56,7 +57,7 @@ test('defaults to 60 seconds if no timeout is specified', () => {
   expect(options.timeout).toEqual(60000);
 });
 
-test('should not set userVerification if not specified', () => {
+test('should set userVerification to "preferred" if not specified', () => {
   const options = generateAuthenticationOptions({
     challenge: challengeBuffer,
     allowCredentials: [
@@ -65,7 +66,7 @@ test('should not set userVerification if not specified', () => {
     ],
   });
 
-  expect(options.userVerification).toEqual(undefined);
+  expect(options.userVerification).toEqual('preferred');
 });
 
 test('should not set allowCredentials if not specified', () => {
@@ -82,7 +83,7 @@ test('should generate without params', () => {
     extensions: undefined,
     rpId: undefined,
     timeout: 60000,
-    userVerification: undefined,
+    userVerification: 'preferred',
   });
   expect(typeof challenge).toEqual('string');
 });

--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -37,7 +37,7 @@ export function generateAuthenticationOptions(
     allowCredentials,
     challenge = generateChallenge(),
     timeout = 60000,
-    userVerification,
+    userVerification = 'preferred',
     extensions,
     rpID,
   } = options;

--- a/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
@@ -29,6 +29,7 @@ test('should verify an assertion response', async () => {
     expectedOrigin: assertionOrigin,
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -41,6 +42,7 @@ test('should return authenticator info after verification', async () => {
     expectedOrigin: assertionOrigin,
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.authenticationInfo.newCounter).toEqual(144);
@@ -122,6 +124,7 @@ test('should throw error if previous counter value is not less than in response'
       expectedOrigin: assertionOrigin,
       expectedRPID: 'dev.dontneeda.pw',
       authenticator: badDevice,
+      requireUserVerification: false,
     }),
   ).rejects.toThrow(/counter value/i);
 });
@@ -150,6 +153,7 @@ test('should not compare counters if both are 0', async () => {
     expectedOrigin: assertionFirstTimeUsedOrigin,
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticatorFirstTimeUsed,
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -220,6 +224,7 @@ test('should support multiple possible origins', async () => {
     expectedOrigin: ['https://simplewebauthn.dev', assertionOrigin],
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -244,6 +249,7 @@ test('should support multiple possible RP IDs', async () => {
     expectedOrigin: assertionOrigin,
     expectedRPID: ['dev.dontneeda.pw', 'simplewebauthn.dev'],
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -367,6 +373,7 @@ test('should return credential backup info', async () => {
     expectedOrigin: assertionOrigin,
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.authenticationInfo?.credentialDeviceType).toEqual('singleDevice');
@@ -443,6 +450,7 @@ test('should return user verified flag after successful auth', async () => {
     expectedOrigin: assertionOrigin,
     expectedRPID: 'dev.dontneeda.pw',
     authenticator: authenticator,
+    requireUserVerification: false,
   });
 
   expect(verification.authenticationInfo?.userVerified).toBeDefined();

--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -54,7 +54,7 @@ export async function verifyAuthenticationResponse(
     expectedOrigin,
     expectedRPID,
     authenticator,
-    requireUserVerification,
+    requireUserVerification = true,
     advancedFIDOConfig,
   } = options;
   const { id, rawId, type: credentialType, response } = credential;

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -48,7 +48,8 @@ test('should generate credential request options suitable for sending via JSON',
     attestation: attestationType,
     excludeCredentials: [],
     authenticatorSelection: {
-      requireResidentKey: false,
+      requireResidentKey: true,
+      residentKey: 'required',
       userVerification: 'preferred',
     },
   });
@@ -197,7 +198,7 @@ test('should discourage resident key if residentKey option is absent but require
   expect(options.authenticatorSelection?.residentKey).toBeUndefined();
 });
 
-test('should not set resident key if both residentKey and requireResidentKey options are absent', () => {
+test('should require resident key if both residentKey and requireResidentKey options are absent', () => {
   const options = generateRegistrationOptions({
     rpID: 'not.real',
     rpName: 'SimpleWebAuthn',
@@ -205,8 +206,8 @@ test('should not set resident key if both residentKey and requireResidentKey opt
     userName: 'usernameHere',
   });
 
-  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
-  expect(options.authenticatorSelection?.residentKey).toBeUndefined();
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(true);
+  expect(options.authenticatorSelection?.residentKey).toEqual('required');
 });
 
 test('should set requireResidentKey to true if residentKey if set to required', () => {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -62,7 +62,7 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
  * defaults.
  */
 const defaultAuthenticatorSelection: AuthenticatorSelectionCriteria = {
-  requireResidentKey: false,
+  residentKey: 'required',
   userVerification: 'preferred',
 };
 

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
@@ -21,6 +21,7 @@ test('should verify TPM response', async () => {
     expectedChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -52,6 +53,7 @@ test('should verify SHA1 TPM response', async () => {
     expectedChallenge,
     expectedOrigin: 'https://localhost:44329',
     expectedRPID: 'localhost',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -83,6 +85,7 @@ test('should verify SHA256 TPM response', async () => {
     expectedChallenge,
     expectedOrigin: 'https://localhost:44329',
     expectedRPID: 'localhost',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);

--- a/packages/server/src/registration/verifications/verifyAttestationAndroidKey.test.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationAndroidKey.test.ts
@@ -29,6 +29,7 @@ test('should verify Android KeyStore response', async () => {
     expectedChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -47,6 +47,7 @@ test('should verify FIDO U2F attestation', async () => {
     expectedChallenge: attestationFIDOU2FChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -89,7 +90,7 @@ test('should verify Packed (EC2) attestation', async () => {
   expect(verification.registrationInfo?.credentialID).toEqual(
     isoBase64URL.toBuffer(
       'AYThY1csINY4JrbHyGmqTl1nL_F1zjAF3hSAIngz8kAcjugmAMNVvxZRwqpEH-bNHHAIv291OX5ko9eDf_5mu3U' +
-        'B2BvsScr2K-ppM4owOpGsqwg5tZglqqmxIm1Q',
+      'B2BvsScr2K-ppM4owOpGsqwg5tZglqqmxIm1Q',
     ),
   );
 });
@@ -100,6 +101,7 @@ test('should verify Packed (X5C) attestation', async () => {
     expectedChallenge: attestationPackedX5CChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -290,6 +292,7 @@ test('should throw if the authenticator does not give back credential ID', async
       expectedChallenge: attestationNoneChallenge,
       expectedOrigin: 'https://dev.dontneeda.pw',
       expectedRPID: 'dev.dontneeda.pw',
+      requireUserVerification: false,
     }),
   ).rejects.toThrow(/credential id/i);
 });
@@ -310,6 +313,7 @@ test('should throw if the authenticator does not give back credential public key
       expectedChallenge: attestationNoneChallenge,
       expectedOrigin: 'https://dev.dontneeda.pw',
       expectedRPID: 'dev.dontneeda.pw',
+      requireUserVerification: false,
     }),
   ).rejects.toThrow(/public key/i);
 });
@@ -351,6 +355,7 @@ test('should not include authenticator info if not verified', async () => {
     expectedChallenge: attestationFIDOU2FChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toBe(false);
@@ -396,6 +401,7 @@ test('should validate TPM RSA response (SHA256)', async () => {
     expectedChallenge: expectedChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -430,6 +436,7 @@ test('should validate TPM RSA response (SHA1)', async () => {
     expectedChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -464,6 +471,7 @@ test('should validate Android-Key response', async () => {
     expectedChallenge,
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
+    requireUserVerification: false,
   });
 
   expect(verification.verified).toEqual(true);
@@ -632,6 +640,7 @@ test('should verify FIDO U2F attestation that specifies SHA-1 in its leaf cert p
     expectedChallenge: 'wJ6mrZnkb69GD5d9_fUz9-NgRHE0z10quXUBSa9xK5o',
     expectedOrigin: 'http://localhost:8000',
     expectedRPID: 'localhost',
+    requireUserVerification: false,
   });
 });
 
@@ -653,6 +662,7 @@ test('should verify Packed attestation with RSA-PSS SHA-256 public key', async (
     expectedChallenge: '40v_izMpzX-LONIGzGq0YbxDwMKMfd_XxQzpe6Wv64Y',
     expectedOrigin: 'http://localhost:8000',
     expectedRPID: 'localhost',
+    requireUserVerification: false,
   });
 });
 
@@ -674,6 +684,7 @@ test('should verify Packed attestation with RSA-PSS SHA-384 public key', async (
     expectedChallenge: 'p-jaXHfYJdld6y5nrIsa6rnZf6rgSC-Fo1q7ASMU7k8',
     expectedOrigin: 'http://localhost:8000',
     expectedRPID: 'localhost',
+    requireUserVerification: false,
   });
 });
 

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -61,7 +61,7 @@ export async function verifyRegistrationResponse(
     expectedChallenge,
     expectedOrigin,
     expectedRPID,
-    requireUserVerification = false,
+    requireUserVerification = true,
     supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers,
   } = options;
   const { id, rawId, type: credentialType, response } = credential;


### PR DESCRIPTION
This PR makes SimpleWebAuthn more opinionated about default functionality, and the use case it promotes. In this case the defaults will steer RP's towards implementing **passwordless** authentication thusly:

- Explicitly mark user verification as `"preferred"` in registration and authentication options (WebAuthn defaults to this value when `userVerification` is missing in options)
- Require a discoverable credential be created in registration options
- Require user verification having taken place (i.e. `uv:true`) during registration and authentication response verification

These changes were inspired by [recent doc updates made to passkeys.dev](https://passkeys.dev/docs/use-cases/bootstrapping/#a-note-about-user-verification) on how RP's should mark user verification `"preferred"`, but leaves it up to RP's to figure out if UV should be required or not in response validation:

> The user verification result (conveyed in [authenticator data flags](https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#flags)) will reflect the actual user verification result and should always be validated against your requirements on the server.

I'm deciding to make RP's require that user verification is marked `true` in the response to ensure a reliable passwordless experience.

## THIS IS A BREAKING CHANGE!

RP's that do not require support for discoverable credentials from authenticators will need to update their calls to `generateRegistrationOptions()` accordingly:

**Before**

```js
const options = generateRegistrationOptions({
  rpName: 'SimpleWebAuthn',
  rpID: 'simplewebauthn.dev',
  userID: '1234',
  userName: 'usernameHere',
});
```

**After**

```js
const options = generateRegistrationOptions({
  rpName: 'SimpleWebAuthn',
  rpID: 'simplewebauthn.dev',
  userID: '1234',
  userName: 'usernameHere',
  authenticatorSelection: {
    // See https://www.w3.org/TR/webauthn-2/#enumdef-residentkeyrequirement
    residentKey: 'discouraged',
  },
});
```

Additionally, RP's implementing a second-factor flow with WebAuthn, where UV is not important (because username+password are provided before WebAuthn is leveraged for the second factor), should not require user verification when verifying responses:

### `verifyRegistrationResponse()`

**Before**

```js
const verification = await verifyRegistrationResponse({
  credential: attestationFIDOU2F,
  // ...
});
```

**After**

```js
const verification = await verifyRegistrationResponse({
  credential: attestationFIDOU2F,
  // ...
  requireUserVerification: false,
});
```

### `verifyAuthenticationResponse()`

**Before**

```js
const verification = await verifyAuthenticationResponse({
  credential: assertionResponse,
  // ...
});
```

**After**

```js
const verification = await verifyAuthenticationResponse({
  credential: assertionResponse,
  // ...
  requireUserVerification: false,
});
```