### PR TITLE
feat/faster-cert-chain-validation

### DIFF
--- a/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
@@ -1,6 +1,6 @@
 import { AsnParser } from '@peculiar/asn1-schema';
 import { Certificate } from '@peculiar/asn1-x509';
-import { ECParameters, id_ecPublicKey, id_secp256r1 } from '@peculiar/asn1-ecc';
+import { ECParameters, id_ecPublicKey, id_secp256r1, id_secp384r1 } from '@peculiar/asn1-ecc';
 import { RSAPublicKey } from '@peculiar/asn1-rsa';
 
 import {
@@ -41,8 +41,12 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
     );
 
     let crv = -999;
-    if (ecParameters.namedCurve === id_secp256r1) {
+    const { namedCurve } = ecParameters;
+
+    if (namedCurve === id_secp256r1) {
       crv = COSECRV.P256;
+    } else if (namedCurve === id_secp384r1) {
+      crv = COSECRV.P384;
     } else {
       throw new Error(
         `Leaf cert public key contained unexpected namedCurve ${ecParameters.namedCurve} (EC2)`,

--- a/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
@@ -48,9 +48,7 @@ export function convertX509PublicKeyToCOSE(x509Certificate: Uint8Array): COSEPub
     } else if (namedCurve === id_secp384r1) {
       crv = COSECRV.P384;
     } else {
-      throw new Error(
-        `Certificate public key contained unexpected namedCurve ${namedCurve} (EC2)`,
-      );
+      throw new Error(`Certificate public key contained unexpected namedCurve ${namedCurve} (EC2)`);
     }
 
     const subjectPublicKey = new Uint8Array(subjectPublicKeyInfo.subjectPublicKey);
@@ -90,7 +88,7 @@ export function convertX509PublicKeyToCOSE(x509Certificate: Uint8Array): COSEPub
     cosePublicKey = coseRSAPubKey;
   } else {
     throw new Error(
-      `Certificate public key contained unexpected algorithm ID ${publicKeyAlgorithmID}`
+      `Certificate public key contained unexpected algorithm ID ${publicKeyAlgorithmID}`,
     );
   }
 

--- a/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
@@ -10,8 +10,8 @@ import {
   COSEKEYS,
   COSEPublicKeyEC2,
   COSEPublicKeyRSA,
-  COSEALG,
 } from './cose';
+import { mapX509SignatureAlgToCOSEAlg } from './mapX509SignatureAlgToCOSEAlg';
 
 export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPublicKey {
   let cosePublicKey: COSEPublicKey = new Map();
@@ -65,7 +65,7 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
 
     const coseEC2PubKey: COSEPublicKeyEC2 = new Map();
     coseEC2PubKey.set(COSEKEYS.kty, COSEKTY.EC2);
-    coseEC2PubKey.set(COSEKEYS.alg, signatureAlgorithmToCOSEAlg(signatureAlgorithm));
+    coseEC2PubKey.set(COSEKEYS.alg, mapX509SignatureAlgToCOSEAlg(signatureAlgorithm));
     coseEC2PubKey.set(COSEKEYS.crv, crv);
     coseEC2PubKey.set(COSEKEYS.x, x);
     coseEC2PubKey.set(COSEKEYS.y, y);
@@ -79,7 +79,7 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
 
     const coseRSAPubKey: COSEPublicKeyRSA = new Map();
     coseRSAPubKey.set(COSEKEYS.kty, COSEKTY.RSA);
-    coseRSAPubKey.set(COSEKEYS.alg, signatureAlgorithmToCOSEAlg(signatureAlgorithm));
+    coseRSAPubKey.set(COSEKEYS.alg, mapX509SignatureAlgToCOSEAlg(signatureAlgorithm));
     coseRSAPubKey.set(COSEKEYS.n, new Uint8Array(rsaPublicKey.modulus));
     coseRSAPubKey.set(COSEKEYS.e, new Uint8Array(rsaPublicKey.publicExponent));
 
@@ -89,36 +89,4 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
   }
 
   return cosePublicKey;
-}
-
-/**
- * Map X.509 signature algorithm OIDs to COSE algorithm IDs
- *
- * - EC2 OIDs: https://oidref.com/1.2.840.10045.4.3
- * - RSA OIDs: https://oidref.com/1.2.840.113549.1.1
- */
-function signatureAlgorithmToCOSEAlg(signatureAlgorithm: string): COSEALG {
-  let alg: COSEALG;
-
-  if (signatureAlgorithm === '1.2.840.10045.4.3.2') {
-    alg = COSEALG.ES256;
-  } else if (signatureAlgorithm === '1.2.840.10045.4.3.3') {
-    alg = COSEALG.ES384;
-  } else if (signatureAlgorithm === '1.2.840.10045.4.3.4') {
-    alg = COSEALG.ES512;
-  } else if (signatureAlgorithm === '1.2.840.113549.1.1.11') {
-    alg = COSEALG.RS256;
-  } else if (signatureAlgorithm === '1.2.840.113549.1.1.12') {
-    alg = COSEALG.RS384;
-  } else if (signatureAlgorithm === '1.2.840.113549.1.1.13') {
-    alg = COSEALG.RS512;
-  } else if (signatureAlgorithm === '1.2.840.113549.1.1.5') {
-    alg = COSEALG.RS1;
-  } else {
-    throw new Error(
-      `Leaf cert contained unexpected signature algorithm ${signatureAlgorithm} (EC2)`,
-    );
-  }
-
-  return alg;
 }

--- a/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/convertX509PublicKeyToCOSE.ts
@@ -13,13 +13,13 @@ import {
 } from './cose';
 import { mapX509SignatureAlgToCOSEAlg } from './mapX509SignatureAlgToCOSEAlg';
 
-export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPublicKey {
+export function convertX509PublicKeyToCOSE(x509Certificate: Uint8Array): COSEPublicKey {
   let cosePublicKey: COSEPublicKey = new Map();
 
   /**
-   * Time to extract the public key from an X.509 leaf certificate
+   * Time to extract the public key from an X.509 certificate
    */
-  const x509 = AsnParser.parse(leafCertificate, Certificate);
+  const x509 = AsnParser.parse(x509Certificate, Certificate);
 
   const { tbsCertificate } = x509;
   const { subjectPublicKeyInfo, signature: _tbsSignature } = tbsCertificate;
@@ -32,7 +32,7 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
      * EC2 Public Key
      */
     if (!subjectPublicKeyInfo.algorithm.parameters) {
-      throw new Error('Leaf cert public key missing parameters (EC2)');
+      throw new Error('Certificate public key was missing parameters (EC2)');
     }
 
     const ecParameters = AsnParser.parse(
@@ -49,7 +49,7 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
       crv = COSECRV.P384;
     } else {
       throw new Error(
-        `Leaf cert public key contained unexpected namedCurve ${ecParameters.namedCurve} (EC2)`,
+        `Certificate public key contained unexpected namedCurve ${namedCurve} (EC2)`,
       );
     }
 
@@ -89,7 +89,9 @@ export function convertX509PublicKeyToCOSE(leafCertificate: Uint8Array): COSEPub
 
     cosePublicKey = coseRSAPubKey;
   } else {
-    throw new Error(`Unexpected leaf cert public key algorithm ${publicKeyAlgorithmID}`);
+    throw new Error(
+      `Certificate public key contained unexpected algorithm ID ${publicKeyAlgorithmID}`
+    );
   }
 
   return cosePublicKey;

--- a/packages/server/src/helpers/isCertRevoked.ts
+++ b/packages/server/src/helpers/isCertRevoked.ts
@@ -34,7 +34,7 @@ export async function isCertRevoked(cert: Certificate): Promise<boolean> {
   const { extensions } = cert.tbsCertificate;
 
   if (!extensions) {
-    throw new Error('Certificate had no extensions needed to check for revocation');
+    return false;
   }
 
   let extAuthorityKeyID: AuthorityKeyIdentifier | undefined;

--- a/packages/server/src/helpers/isCertRevoked.ts
+++ b/packages/server/src/helpers/isCertRevoked.ts
@@ -41,7 +41,7 @@ export async function isCertRevoked(cert: Certificate): Promise<boolean> {
   let extSubjectKeyID: SubjectKeyIdentifier | undefined;
   let extCRLDistributionPoints: CRLDistributionPoints | undefined;
 
-  extensions.forEach((ext) => {
+  extensions.forEach(ext => {
     if (ext.extnID === id_ce_authorityKeyIdentifier) {
       extAuthorityKeyID = AsnParser.parse(ext.extnValue, AuthorityKeyIdentifier);
     } else if (ext.extnID === id_ce_subjectKeyIdentifier) {
@@ -55,17 +55,13 @@ export async function isCertRevoked(cert: Certificate): Promise<boolean> {
   let keyIdentifier: string | undefined = undefined;
 
   if (extAuthorityKeyID && extAuthorityKeyID.keyIdentifier) {
-    keyIdentifier = isoUint8Array.toHex(
-      new Uint8Array(extAuthorityKeyID.keyIdentifier.buffer),
-    );
+    keyIdentifier = isoUint8Array.toHex(new Uint8Array(extAuthorityKeyID.keyIdentifier.buffer));
   } else if (extSubjectKeyID) {
     /**
      * We might be dealing with a self-signed root certificate. Check the
      * Subject key Identifier extension next.
      */
-    keyIdentifier = isoUint8Array.toHex(
-      new Uint8Array(extSubjectKeyID.buffer),
-    );
+    keyIdentifier = isoUint8Array.toHex(new Uint8Array(extSubjectKeyID.buffer));
   }
 
   const certSerialHex = isoUint8Array.toHex(new Uint8Array(cert.tbsCertificate.serialNumber));
@@ -81,7 +77,8 @@ export async function isCertRevoked(cert: Certificate): Promise<boolean> {
     }
   }
 
-  const crlURL = extCRLDistributionPoints?.[0].distributionPoint?.fullName?.[0].uniformResourceIdentifier;
+  const crlURL =
+    extCRLDistributionPoints?.[0].distributionPoint?.fullName?.[0].uniformResourceIdentifier;
 
   // If no URL is provided then we have nothing to check
   if (!crlURL) {

--- a/packages/server/src/helpers/isCertRevoked.ts
+++ b/packages/server/src/helpers/isCertRevoked.ts
@@ -97,7 +97,13 @@ export async function isCertRevoked(cert: Certificate): Promise<boolean> {
     return false;
   }
 
-  const data = AsnParser.parse(certListBytes, CertificateList);
+  let data: CertificateList;
+  try {
+    data = AsnParser.parse(certListBytes, CertificateList);
+  } catch (err) {
+    // Something was malformed with the CRL, so pass
+    return false;
+  }
 
   const newCached: CAAuthorityInfo = {
     revokedCerts: [],

--- a/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoAlg.ts
@@ -15,5 +15,5 @@ export function mapCoseAlgToWebCryptoAlg(alg: COSEALG): SubtleCryptoAlg {
     return 'SHA-512';
   }
 
-  throw new Error(`Unexpected COSE alg value of ${alg}`);
+  throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
 }

--- a/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.ts
@@ -15,5 +15,5 @@ export function mapCoseAlgToWebCryptoKeyAlgName(alg: COSEALG): SubtleCryptoKeyAl
     return 'RSA-PSS';
   }
 
-  throw new Error(`Unexpected COSE alg value of ${alg}`);
+  throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto key alg name`);
 }

--- a/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoKeyAlgName.ts
@@ -9,7 +9,7 @@ export function mapCoseAlgToWebCryptoKeyAlgName(alg: COSEALG): SubtleCryptoKeyAl
     return 'Ed25519';
   } else if ([COSEALG.ES256, COSEALG.ES384, COSEALG.ES512, COSEALG.ES256K].indexOf(alg) >= 0) {
     return 'ECDSA';
-  } else if ([COSEALG.RS256, COSEALG.RS384, COSEALG.RS512].indexOf(alg) >= 0) {
+  } else if ([COSEALG.RS256, COSEALG.RS384, COSEALG.RS512, COSEALG.RS1].indexOf(alg) >= 0) {
     return 'RSASSA-PKCS1-v1_5';
   } else if ([COSEALG.PS256, COSEALG.PS384, COSEALG.PS512].indexOf(alg) >= 0) {
     return 'RSA-PSS';

--- a/packages/server/src/helpers/mapX509SignatureAlgToCOSEAlg.ts
+++ b/packages/server/src/helpers/mapX509SignatureAlgToCOSEAlg.ts
@@ -1,0 +1,33 @@
+import { COSEALG } from './cose';
+
+/**
+ * Map X.509 signature algorithm OIDs to COSE algorithm IDs
+ *
+ * - EC2 OIDs: https://oidref.com/1.2.840.10045.4.3
+ * - RSA OIDs: https://oidref.com/1.2.840.113549.1.1
+ */
+export function mapX509SignatureAlgToCOSEAlg(signatureAlgorithm: string): COSEALG {
+  let alg: COSEALG;
+
+  if (signatureAlgorithm === '1.2.840.10045.4.3.2') {
+    alg = COSEALG.ES256;
+  } else if (signatureAlgorithm === '1.2.840.10045.4.3.3') {
+    alg = COSEALG.ES384;
+  } else if (signatureAlgorithm === '1.2.840.10045.4.3.4') {
+    alg = COSEALG.ES512;
+  } else if (signatureAlgorithm === '1.2.840.113549.1.1.11') {
+    alg = COSEALG.RS256;
+  } else if (signatureAlgorithm === '1.2.840.113549.1.1.12') {
+    alg = COSEALG.RS384;
+  } else if (signatureAlgorithm === '1.2.840.113549.1.1.13') {
+    alg = COSEALG.RS512;
+  } else if (signatureAlgorithm === '1.2.840.113549.1.1.5') {
+    alg = COSEALG.RS1;
+  } else {
+    throw new Error(
+      `Unable to map X.509 signature algorithm ${signatureAlgorithm} to a COSE algorithm`,
+    );
+  }
+
+  return alg;
+}

--- a/packages/server/src/helpers/validateCertificatePath.ts
+++ b/packages/server/src/helpers/validateCertificatePath.ts
@@ -6,7 +6,7 @@ import { X509, zulutodate } from 'jsrsasign';
 import { isCertRevoked } from './isCertRevoked';
 import { isoBase64URL } from './iso';
 import { verifySignature } from './verifySignature';
-import { signatureAlgorithmToCOSEAlg } from './convertX509PublicKeyToCOSE';
+import { mapX509SignatureAlgToCOSEAlg } from './mapX509SignatureAlgToCOSEAlg';
 
 /**
  * Traverse an array of PEM certificates and ensure they form a proper chain
@@ -117,7 +117,9 @@ async function _validatePath(certificates: string[]): Promise<boolean> {
 
     const data = AsnSerializer.serialize(x509Subject.tbsCertificate);
     const signature = x509Subject.signatureValue;
-    const signatureAlgorithm = signatureAlgorithmToCOSEAlg(x509Subject.signatureAlgorithm.algorithm);
+    const signatureAlgorithm = mapX509SignatureAlgToCOSEAlg(
+      x509Subject.signatureAlgorithm.algorithm,
+    );
     const issuerCertBytes = pemToBytes(issuerPem);
 
     const verified = await verifySignature({

--- a/packages/server/src/helpers/validateCertificatePath.ts
+++ b/packages/server/src/helpers/validateCertificatePath.ts
@@ -125,8 +125,8 @@ async function _validatePath(certificates: string[]): Promise<boolean> {
     const verified = await verifySignature({
       data: new Uint8Array(data),
       signature: new Uint8Array(signature),
-      leafCertificate: issuerCertBytes,
-      attestationHashAlgorithm: signatureAlgorithm,
+      x509Certificate: issuerCertBytes,
+      hashAlgorithm: signatureAlgorithm,
     });
 
     if (!verified) {

--- a/packages/server/src/helpers/verifySignature.ts
+++ b/packages/server/src/helpers/verifySignature.ts
@@ -10,16 +10,16 @@ export async function verifySignature(opts: {
   signature: Uint8Array;
   data: Uint8Array;
   credentialPublicKey?: Uint8Array;
-  leafCertificate?: Uint8Array;
-  attestationHashAlgorithm?: COSEALG;
+  x509Certificate?: Uint8Array;
+  hashAlgorithm?: COSEALG;
 }): Promise<boolean> {
-  const { signature, data, credentialPublicKey, leafCertificate, attestationHashAlgorithm } = opts;
+  const { signature, data, credentialPublicKey, x509Certificate, hashAlgorithm } = opts;
 
-  if (!leafCertificate && !credentialPublicKey) {
+  if (!x509Certificate && !credentialPublicKey) {
     throw new Error('Must declare either "leafCert" or "credentialPublicKey"');
   }
 
-  if (leafCertificate && credentialPublicKey) {
+  if (x509Certificate && credentialPublicKey) {
     throw new Error('Must not declare both "leafCert" and "credentialPublicKey"');
   }
 
@@ -27,14 +27,14 @@ export async function verifySignature(opts: {
 
   if (credentialPublicKey) {
     cosePublicKey = decodeCredentialPublicKey(credentialPublicKey);
-  } else if (leafCertificate) {
-    cosePublicKey = convertX509PublicKeyToCOSE(leafCertificate);
+  } else if (x509Certificate) {
+    cosePublicKey = convertX509PublicKeyToCOSE(x509Certificate);
   }
 
   return isoCrypto.verify({
     cosePublicKey,
     signature,
     data,
-    shaHashOverride: attestationHashAlgorithm,
+    shaHashOverride: hashAlgorithm,
   });
 }

--- a/packages/server/src/metadata/verifyAttestationWithMetadata.test.ts
+++ b/packages/server/src/metadata/verifyAttestationWithMetadata.test.ts
@@ -175,51 +175,53 @@ test('should verify idmelon attestation with updated root certificate', async ()
    * new root certificate, which is included below and will eventually get rolled out via FIDO MDS.
    */
   const metadataStatement: MetadataStatement = {
-    "legalHeader": "Submission of this statement and retrieval and use of this statement indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/.",
-    "aaguid": "820d89ed-d65a-409e-85cb-f73f0578f82a",
-    "description": "Vancosys iOS Authenticator",
-    "authenticatorVersion": 2,
-    "protocolFamily": "fido2",
-    "schema": 3,
-    "upv": [{ "major": 1, "minor": 0 }],
-    "authenticationAlgorithms": ["secp256r1_ecdsa_sha256_raw"],
-    "publicKeyAlgAndEncodings": ["cose"],
-    "attestationTypes": ["basic_full"],
-    "userVerificationDetails": [
+    legalHeader:
+      'Submission of this statement and retrieval and use of this statement indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/.',
+    aaguid: '820d89ed-d65a-409e-85cb-f73f0578f82a',
+    description: 'Vancosys iOS Authenticator',
+    authenticatorVersion: 2,
+    protocolFamily: 'fido2',
+    schema: 3,
+    upv: [{ major: 1, minor: 0 }],
+    authenticationAlgorithms: ['secp256r1_ecdsa_sha256_raw'],
+    publicKeyAlgAndEncodings: ['cose'],
+    attestationTypes: ['basic_full'],
+    userVerificationDetails: [
       [
-        { "userVerificationMethod": "faceprint_internal" },
-        { "userVerificationMethod": "voiceprint_internal" },
-        { "userVerificationMethod": "passcode_internal" },
-        { "userVerificationMethod": "eyeprint_internal" },
-        { "userVerificationMethod": "handprint_internal" },
-        { "userVerificationMethod": "fingerprint_internal" },
-        { "userVerificationMethod": "pattern_internal" },
-        { "userVerificationMethod": "location_internal" },
-        { "userVerificationMethod": "presence_internal" },
-      ]
+        { userVerificationMethod: 'faceprint_internal' },
+        { userVerificationMethod: 'voiceprint_internal' },
+        { userVerificationMethod: 'passcode_internal' },
+        { userVerificationMethod: 'eyeprint_internal' },
+        { userVerificationMethod: 'handprint_internal' },
+        { userVerificationMethod: 'fingerprint_internal' },
+        { userVerificationMethod: 'pattern_internal' },
+        { userVerificationMethod: 'location_internal' },
+        { userVerificationMethod: 'presence_internal' },
+      ],
     ],
-    "keyProtection": ["hardware", "secure_element"],
-    "matcherProtection": ["on_chip"],
-    "cryptoStrength": 128,
-    "attachmentHint": ["external"],
-    "tcDisplay": [],
-    "attestationRootCertificates": [
-      "MIIByzCCAXGgAwIBAgIJANmMNK6jVpuuMAoGCCqGSM49BAMCMEExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEZMBcGA1UEAwwQVmFuY29zeXMgUm9vdCBDQTAgFw0yMjEyMTQxODQxMDlaGA8yMDcyMTIwMTE4NDEwOVowQTEkMCIGA1UECgwbVmFuY29zeXMgRGF0YSBTZWN1cml0eSBJbmMuMRkwFwYDVQQDDBBWYW5jb3N5cyBSb290IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEalYgEopnKScAm+d9f1XpGB3zbkZCD3hZEKuxTclpBYlj4ypNRg0gMSa7geBgd6nck50YaVhdy75uIc2wbWX8t6NQME4wHQYDVR0OBBYEFOxyf0cDs8Yl+VnWSZ1uYJAKkFeVMB8GA1UdIwQYMBaAFOxyf0cDs8Yl+VnWSZ1uYJAKkFeVMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAO2XuiRDXxy/UkWhsuZQYNUXeOj08AeTWADAqXvcA30hAiBi2cdGd61PNwHDTYjXPenPcD8S0rFTDncNWfs3E/WDXA=="
+    keyProtection: ['hardware', 'secure_element'],
+    matcherProtection: ['on_chip'],
+    cryptoStrength: 128,
+    attachmentHint: ['external'],
+    tcDisplay: [],
+    attestationRootCertificates: [
+      'MIIByzCCAXGgAwIBAgIJANmMNK6jVpuuMAoGCCqGSM49BAMCMEExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEZMBcGA1UEAwwQVmFuY29zeXMgUm9vdCBDQTAgFw0yMjEyMTQxODQxMDlaGA8yMDcyMTIwMTE4NDEwOVowQTEkMCIGA1UECgwbVmFuY29zeXMgRGF0YSBTZWN1cml0eSBJbmMuMRkwFwYDVQQDDBBWYW5jb3N5cyBSb290IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEalYgEopnKScAm+d9f1XpGB3zbkZCD3hZEKuxTclpBYlj4ypNRg0gMSa7geBgd6nck50YaVhdy75uIc2wbWX8t6NQME4wHQYDVR0OBBYEFOxyf0cDs8Yl+VnWSZ1uYJAKkFeVMB8GA1UdIwQYMBaAFOxyf0cDs8Yl+VnWSZ1uYJAKkFeVMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAO2XuiRDXxy/UkWhsuZQYNUXeOj08AeTWADAqXvcA30hAiBi2cdGd61PNwHDTYjXPenPcD8S0rFTDncNWfs3E/WDXA==',
     ],
-    "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAM1BMVEUtmc3y+fyWzOZis9rK5fI6n9B8v+Cw2ezl8vlHptNVrNbX7Paj0ulvud293++JxuP///89HRvpAAAAEXRSTlP/////////////////////ACWtmWIAAABsSURBVHgBxdPBCoAwDIPh/yDise//tIIQCZo6RNGdtuWDstFSg/UOgMiADQBJ6J4iCwS4BgzBuEQHCoFa+mdM+qijsDMVhBfdoRFaAL4nAe6AeghODYPnsaNyLuAqg5AHwO9AYu5BmqEPhncFmecvM5KKQHMAAAAASUVORK5CYII=",
-    "authenticatorGetInfo": {
-      "versions": ["FIDO_2_0"],
-      "extensions": ["hmac-secret"],
-      "aaguid": "820d89edd65a409e85cbf73f0578f82a",
-      "options": { "plat": false, "rk": true, "up": true, "uv": true },
-      "maxMsgSize": 2048
-    }
+    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAM1BMVEUtmc3y+fyWzOZis9rK5fI6n9B8v+Cw2ezl8vlHptNVrNbX7Paj0ulvud293++JxuP///89HRvpAAAAEXRSTlP/////////////////////ACWtmWIAAABsSURBVHgBxdPBCoAwDIPh/yDise//tIIQCZo6RNGdtuWDstFSg/UOgMiADQBJ6J4iCwS4BgzBuEQHCoFa+mdM+qijsDMVhBfdoRFaAL4nAe6AeghODYPnsaNyLuAqg5AHwO9AYu5BmqEPhncFmecvM5KKQHMAAAAASUVORK5CYII=',
+    authenticatorGetInfo: {
+      versions: ['FIDO_2_0'],
+      extensions: ['hmac-secret'],
+      aaguid: '820d89edd65a409e85cbf73f0578f82a',
+      options: { plat: false, rk: true, up: true, uv: true },
+      maxMsgSize: 2048,
+    },
   };
 
   const x5c = [
-    'MIIB6TCCAY+gAwIBAgIJAJz56pzvu76hMAoGCCqGSM49BAMCMEExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEZMBcGA1UEAwwQVmFuY29zeXMgUm9vdCBDQTAgFw0xODEyMjIxNzQzMjhaGA8yMDY4MTIwOTE3NDMyOFowfDELMAkGA1UEBhMCQ0ExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEjMCEGA1UEAwwaVmFuY29zeXMgaU9TIEF1dGhlbnRpY2F0b3IwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATZVzbtmSJbzsoN6mfdD+t1LV52zB+LWN0UusmV9+sRmfNB49adqPQ+h0JOlEwfL4zkbMmuDr6JhBRKJ5/c0SkeozMwMTAMBgNVHRMBAf8EAjAAMCEGCysGAQQBguUcAQEEBBIEEIINie3WWkCehcv3PwV4+CowCgYIKoZIzj0EAwIDSAAwRQIgV7++U2fQyy6Qido7fDhsi5Grrt76LTgZ5XJlA9UKEVECIQDJO0YHevdU77VlZ+Of58oKMjWD3SkzC1SWSlhl3nezHQ=='
+    'MIIB6TCCAY+gAwIBAgIJAJz56pzvu76hMAoGCCqGSM49BAMCMEExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEZMBcGA1UEAwwQVmFuY29zeXMgUm9vdCBDQTAgFw0xODEyMjIxNzQzMjhaGA8yMDY4MTIwOTE3NDMyOFowfDELMAkGA1UEBhMCQ0ExJDAiBgNVBAoMG1ZhbmNvc3lzIERhdGEgU2VjdXJpdHkgSW5jLjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEjMCEGA1UEAwwaVmFuY29zeXMgaU9TIEF1dGhlbnRpY2F0b3IwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATZVzbtmSJbzsoN6mfdD+t1LV52zB+LWN0UusmV9+sRmfNB49adqPQ+h0JOlEwfL4zkbMmuDr6JhBRKJ5/c0SkeozMwMTAMBgNVHRMBAf8EAjAAMCEGCysGAQQBguUcAQEEBBIEEIINie3WWkCehcv3PwV4+CowCgYIKoZIzj0EAwIDSAAwRQIgV7++U2fQyy6Qido7fDhsi5Grrt76LTgZ5XJlA9UKEVECIQDJO0YHevdU77VlZ+Of58oKMjWD3SkzC1SWSlhl3nezHQ==',
   ];
-  const credentialPublicKey = 'pQECAyYgASFYINuJbeLdkZwgKtUw2VSopICTTO5PKdj95GXJ7JCsQi7iIlggxygEp0_P0oMXhfw2BjtL0M7-yIpnk5uSHc0oNkXfdJw';
+  const credentialPublicKey =
+    'pQECAyYgASFYINuJbeLdkZwgKtUw2VSopICTTO5PKdj95GXJ7JCsQi7iIlggxygEp0_P0oMXhfw2BjtL0M7-yIpnk5uSHc0oNkXfdJw';
 
   const verified = await verifyAttestationWithMetadata({
     statement: metadataStatement,
@@ -228,4 +230,4 @@ test('should verify idmelon attestation with updated root certificate', async ()
   });
 
   expect(verified).toEqual(true);
-})
+});

--- a/packages/server/src/metadata/verifyAttestationWithMetadata.ts
+++ b/packages/server/src/metadata/verifyAttestationWithMetadata.ts
@@ -4,13 +4,7 @@ import type { MetadataStatement, AlgSign } from '../metadata/mdsTypes';
 import { convertCertBufferToPEM } from '../helpers/convertCertBufferToPEM';
 import { validateCertificatePath } from '../helpers/validateCertificatePath';
 import { decodeCredentialPublicKey } from '../helpers/decodeCredentialPublicKey';
-import {
-  COSEALG,
-  COSECRV,
-  COSEKEYS,
-  COSEKTY,
-  isCOSEPublicKeyEC2,
-} from '../helpers/cose';
+import { COSEALG, COSECRV, COSEKEYS, COSEKTY, isCOSEPublicKeyEC2 } from '../helpers/cose';
 
 /**
  * Match properties of the authenticator's attestation statement against expected values as

--- a/packages/server/src/metadata/verifyAttestationWithMetadata.ts
+++ b/packages/server/src/metadata/verifyAttestationWithMetadata.ts
@@ -9,7 +9,6 @@ import {
   COSECRV,
   COSEKEYS,
   COSEKTY,
-  COSEPublicKeyEC2,
   isCOSEPublicKeyEC2,
 } from '../helpers/cose';
 

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
@@ -316,8 +316,8 @@ export async function verifyAttestationTPM(
   return verifySignature({
     signature: sig,
     data: certInfo,
-    leafCertificate: x5c[0],
-    attestationHashAlgorithm: alg,
+    x509Certificate: x5c[0],
+    hashAlgorithm: alg,
   });
 }
 

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
@@ -14,7 +14,6 @@ import { decodeCredentialPublicKey } from '../../../helpers/decodeCredentialPubl
 import {
   COSEKEYS,
   isCOSEAlg,
-  COSEKTY,
   isCOSEPublicKeyRSA,
   isCOSEPublicKeyEC2,
   COSEALG,
@@ -215,7 +214,7 @@ export async function verifyAttestationTPM(
   }
 
   // Check that Subject sequence is empty.
-  if (Object.keys(subject).length > 0) {
+  if (subject.combined.length > 0) {
     throw new Error('Certificate subject was not empty (TPM)');
   }
 

--- a/packages/server/src/registration/verifications/verifyAttestationAndroidKey.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationAndroidKey.ts
@@ -111,7 +111,7 @@ export async function verifyAttestationAndroidKey(
   return verifySignature({
     signature: sig,
     data: signatureBase,
-    leafCertificate: x5c[0],
-    attestationHashAlgorithm: alg,
+    x509Certificate: x5c[0],
+    hashAlgorithm: alg,
   });
 }

--- a/packages/server/src/registration/verifications/verifyAttestationAndroidSafetyNet.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationAndroidSafetyNet.ts
@@ -129,7 +129,7 @@ export async function verifyAttestationAndroidSafetyNet(
   const verified = await verifySignature({
     signature: signatureBuffer,
     data: signatureBaseBuffer,
-    leafCertificate: leafCertBuffer,
+    x509Certificate: leafCertBuffer,
   });
   /**
    * END Verify Signature

--- a/packages/server/src/registration/verifications/verifyAttestationApple.test.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationApple.test.ts
@@ -1,7 +1,3 @@
-// TODO: This test can take upwards of 7 seconds to complete locally, more in CI...need to figure
-// out why
-jest.setTimeout(30000);
-
 import { verifyRegistrationResponse } from '../verifyRegistrationResponse';
 
 test('should verify Apple attestation', async () => {

--- a/packages/server/src/registration/verifications/verifyAttestationFIDOU2F.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationFIDOU2F.ts
@@ -62,7 +62,7 @@ export async function verifyAttestationFIDOU2F(
   return verifySignature({
     signature: sig,
     data: signatureBase,
-    leafCertificate: x5c[0],
-    attestationHashAlgorithm: COSEALG.ES256,
+    x509Certificate: x5c[0],
+    hashAlgorithm: COSEALG.ES256,
   });
 }

--- a/packages/server/src/registration/verifications/verifyAttestationPacked.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationPacked.ts
@@ -115,14 +115,14 @@ export async function verifyAttestationPacked(
     verified = await verifySignature({
       signature: sig,
       data: signatureBase,
-      leafCertificate: x5c[0],
+      x509Certificate: x5c[0],
     });
   } else {
     verified = await verifySignature({
       signature: sig,
       data: signatureBase,
       credentialPublicKey,
-      attestationHashAlgorithm: alg,
+      hashAlgorithm: alg,
     });
   }
 

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -90,7 +90,7 @@ test('should verify Packed (EC2) attestation', async () => {
   expect(verification.registrationInfo?.credentialID).toEqual(
     isoBase64URL.toBuffer(
       'AYThY1csINY4JrbHyGmqTl1nL_F1zjAF3hSAIngz8kAcjugmAMNVvxZRwqpEH-bNHHAIv291OX5ko9eDf_5mu3U' +
-      'B2BvsScr2K-ppM4owOpGsqwg5tZglqqmxIm1Q',
+        'B2BvsScr2K-ppM4owOpGsqwg5tZglqqmxIm1Q',
     ),
   );
 });


### PR DESCRIPTION
I accidentally discovered a fix for a performance bottleneck in certificate chain validation thanks to work done in #299. This should address #309. Based on some light testing via FIDO Conformance Tests, execution times seem to have gone down by around 10%. In one circumstance (unit tests) they decreased by as much as 60%.

## Screenshots

Performance of groups of FIDO Metadata Conformance tests that took long enough to execute to get a "execution time flag" generally went down:

### "tpm" - before

<img width="800" alt="Screenshot 2022-12-18 at 7 43 59 AM" src="https://user-images.githubusercontent.com/5166470/208307190-8b9b677a-c792-4fcf-850c-96c6cec4af4c.png">

### "tpm" - after

<img width="800" alt="Screenshot 2022-12-18 at 7 45 50 AM" src="https://user-images.githubusercontent.com/5166470/208307198-2692d9cb-7ee2-4de6-8725-7385a5f77dbd.png">

### "android-safetynet" - before

<img width="800" alt="Screenshot 2022-12-18 at 7 43 57 AM" src="https://user-images.githubusercontent.com/5166470/208307224-326a6eec-127b-4dcd-8999-ceca3a22cca2.png">

### "android-safetynet" - after

<img width="800" alt="Screenshot 2022-12-18 at 7 45 45 AM" src="https://user-images.githubusercontent.com/5166470/208307229-b8e0749c-e6cc-432c-93f8-d259e27cc764.png">

### Metadata - before

<img width="800" alt="Screenshot 2022-12-18 at 7 43 51 AM" src="https://user-images.githubusercontent.com/5166470/208307239-ea4a2adc-c87b-4df1-b4e9-ced4ca5c505f.png">

### Metadata - after

<img width="800" alt="Screenshot 2022-12-18 at 7 45 38 AM" src="https://user-images.githubusercontent.com/5166470/208307244-6e297f12-23ad-46ae-b38d-8c262ccadc61.png">
