### PR TITLE
feat/prefer-rkey

### DIFF
--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -48,8 +48,8 @@ test('should generate credential request options suitable for sending via JSON',
     attestation: attestationType,
     excludeCredentials: [],
     authenticatorSelection: {
-      requireResidentKey: true,
-      residentKey: 'required',
+      requireResidentKey: false,
+      residentKey: 'preferred',
       userVerification: 'preferred',
     },
   });
@@ -198,7 +198,7 @@ test('should discourage resident key if residentKey option is absent but require
   expect(options.authenticatorSelection?.residentKey).toBeUndefined();
 });
 
-test('should require resident key if both residentKey and requireResidentKey options are absent', () => {
+test('should prefer resident key if both residentKey and requireResidentKey options are absent', () => {
   const options = generateRegistrationOptions({
     rpID: 'not.real',
     rpName: 'SimpleWebAuthn',
@@ -206,8 +206,8 @@ test('should require resident key if both residentKey and requireResidentKey opt
     userName: 'usernameHere',
   });
 
-  expect(options.authenticatorSelection?.requireResidentKey).toEqual(true);
-  expect(options.authenticatorSelection?.residentKey).toEqual('required');
+  expect(options.authenticatorSelection?.requireResidentKey).toEqual(false);
+  expect(options.authenticatorSelection?.residentKey).toEqual('preferred');
 });
 
 test('should set requireResidentKey to true if residentKey if set to required', () => {

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -52,6 +52,9 @@ test('should generate credential request options suitable for sending via JSON',
       residentKey: 'preferred',
       userVerification: 'preferred',
     },
+    extensions: {
+      credProps: true,
+    }
   });
 });
 
@@ -135,9 +138,30 @@ test('should set extensions if specified', () => {
     extensions: { appid: 'simplewebauthn' },
   });
 
-  expect(options.extensions).toEqual({
-    appid: 'simplewebauthn',
+  expect(options.extensions?.appid).toEqual('simplewebauthn');
+});
+
+test('should include credProps if extensions are not provided', () => {
+  const options = generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    userID: '1234',
+    userName: 'usernameHere',
   });
+
+  expect(options.extensions?.credProps).toEqual(true);
+});
+
+test('should include credProps if extensions are provided', () => {
+  const options = generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    userID: '1234',
+    userName: 'usernameHere',
+    extensions: { appid: 'simplewebauthn' },
+  });
+
+  expect(options.extensions?.credProps).toEqual(true);
 });
 
 test('should generate a challenge if one is not provided', () => {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -178,6 +178,9 @@ export function generateRegistrationOptions(
       id: isoBase64URL.fromBuffer(cred.id as Uint8Array),
     })),
     authenticatorSelection,
-    extensions,
+    extensions: {
+      ...extensions,
+      credProps: true,
+    },
   };
 }

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -62,7 +62,7 @@ export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
  * defaults.
  */
 const defaultAuthenticatorSelection: AuthenticatorSelectionCriteria = {
-  residentKey: 'required',
+  residentKey: 'preferred',
   userVerification: 'preferred',
 };
 


### PR DESCRIPTION
This PR loosens the default `residentKey` argument to `"preferred"`. And the `credProps` extension is now always included to help provide clarity to RP's on whether the credential a user is registering is a **r**esident **k**ey or not as `clientExtensionResults.credProps.rk` coming out of **browser**'s `startRegistration()`. This requires browsers to support this extension; most evergreen browsers on most major platforms should support this sooner than later.

For some additional context, requiring resident keys in #307 is not strictly necessary for _passwordless_ authentication via WebAuthn. So long as an authenticator can provide user presence and user verification signals then it shouldn't matter whether the credential it responds with is discoverable or not.

In addition, requiring resident keys during registration uses up very limited storage on security keys for those users who want to use them instead of, say, platform authenticators on mobile devices. Preferring the creation of resident keys (a.k.a. discoverable credentials) gives browsers and security keys a chance to work together to avoid exhausting the key's discoverable credential slots that defaulting to `"required"` would not.

Truthfully I can agree with some arguments that `"discouraged"` should be the default value here, since we're talking "passwordless defaults" and not "passkeys defaults". However the passkeys-enabled Android platform authenticator is "opt-in" and will only generate discoverable credentials when `residentKey` is `"preferred"` or `"required"`. To default to `"discouraged"` would mean RPs would need to do user agent analysis of some kind to determine when the user is on Android and set `"preferred"`/`"required"` accordingly. That's...not ideal.

For later: https://github.com/w3c/webauthn/issues/1822 is the issue in which it's highlighted that even `"preferred"` may not be enough as some security keys will opt to create discoverable credentials when they encounter`"preferred"`. 