### PR TITLE
Add sessions to the example app

### DIFF
--- a/example/example-server.d.ts
+++ b/example/example-server.d.ts
@@ -35,5 +35,15 @@ interface LoggedInUser {
   id: string;
   username: string;
   devices: AuthenticatorDevice[];
-  currentChallenge?: string;
+}
+
+declare module 'express-session' {
+  interface SessionData {
+    /**
+     * A simple way of storing a user's current challenge being signed by registration or authentication.
+     * It should be expired after `timeout` milliseconds (optional argument for `generate` methods,
+     * defaults to 60000ms)
+     */
+    currentChallenge?: string;
+  }
 }

--- a/example/index.ts
+++ b/example/index.ts
@@ -54,15 +54,20 @@ const {
 
 app.use(express.static('./public/'));
 app.use(express.json());
-app.use( session( {
-  secret: 'secret123',
-  saveUninitialized: true,
-  resave: false,
-  cookie: { maxAge: 86400000 },
-  store: new MemoryStore( {
-    checkPeriod: 86_400_000 // prune expired entries every 24h
-  } ),
-} ) );
+app.use(
+  session({
+    secret: 'secret123',
+    saveUninitialized: true,
+    resave: false,
+    cookie: {
+      maxAge: 86400000,
+      httpOnly: true, // Ensure to not expose session cookies to clientside scripts
+    },
+    store: new MemoryStore({
+      checkPeriod: 86_400_000, // prune expired entries every 24h
+    }),
+  }),
+);
 
 /**
  * If the words "metadata statements" mean anything to you, you'll want to enable this route. It

--- a/example/index.ts
+++ b/example/index.ts
@@ -10,6 +10,8 @@ import http from 'http';
 import fs from 'fs';
 
 import express from 'express';
+import session from 'express-session';
+import memoryStore from 'memorystore';
 import dotenv from 'dotenv';
 import base64url from 'base64url';
 
@@ -42,6 +44,7 @@ import type {
 import { LoggedInUser } from './example-server';
 
 const app = express();
+const MemoryStore = memoryStore(session);
 
 const {
   ENABLE_CONFORMANCE,
@@ -51,6 +54,15 @@ const {
 
 app.use(express.static('./public/'));
 app.use(express.json());
+app.use( session( {
+  secret: 'secret123',
+  saveUninitialized: true,
+  resave: false,
+  cookie: { maxAge: 86400000 },
+  store: new MemoryStore( {
+    checkPeriod: 86_400_000 // prune expired entries every 24h
+  } ),
+} ) );
 
 /**
  * If the words "metadata statements" mean anything to you, you'll want to enable this route. It
@@ -89,12 +101,6 @@ const inMemoryUserDeviceDB: { [loggedInUserId: string]: LoggedInUser } = {
     id: loggedInUserId,
     username: `user@${rpID}`,
     devices: [],
-    /**
-     * A simple way of storing a user's current challenge being signed by registration or authentication.
-     * It should be expired after `timeout` milliseconds (optional argument for `generate` methods,
-     * defaults to 60000ms)
-     */
-    currentChallenge: undefined,
   },
 };
 
@@ -145,7 +151,7 @@ app.get('/generate-registration-options', (req, res) => {
    * The server needs to temporarily remember this value for verification, so don't lose it until
    * after you verify an authenticator response.
    */
-  inMemoryUserDeviceDB[loggedInUserId].currentChallenge = options.challenge;
+  req.session.currentChallenge = options.challenge;
 
   res.send(options);
 });
@@ -155,7 +161,7 @@ app.post('/verify-registration', async (req, res) => {
 
   const user = inMemoryUserDeviceDB[loggedInUserId];
 
-  const expectedChallenge = user.currentChallenge;
+  const expectedChallenge = req.session.currentChallenge;
 
   let verification: VerifiedRegistrationResponse;
   try {
@@ -194,6 +200,8 @@ app.post('/verify-registration', async (req, res) => {
     }
   }
 
+  req.session.currentChallenge = undefined;
+
   res.send({ verified });
 });
 
@@ -221,7 +229,7 @@ app.get('/generate-authentication-options', (req, res) => {
    * The server needs to temporarily remember this value for verification, so don't lose it until
    * after you verify an authenticator response.
    */
-  inMemoryUserDeviceDB[loggedInUserId].currentChallenge = options.challenge;
+  req.session.currentChallenge = options.challenge;
 
   res.send(options);
 });
@@ -231,7 +239,7 @@ app.post('/verify-authentication', async (req, res) => {
 
   const user = inMemoryUserDeviceDB[loggedInUserId];
 
-  const expectedChallenge = user.currentChallenge;
+  const expectedChallenge = req.session.currentChallenge;
 
   let dbAuthenticator;
   const bodyCredIDBuffer = base64url.toBuffer(body.rawId);
@@ -270,6 +278,8 @@ app.post('/verify-authentication', async (req, res) => {
     // Update the authenticator's counter in the DB to the newest count in the authentication
     dbAuthenticator.counter = authenticationInfo.newCounter;
   }
+
+  req.session.currentChallenge = undefined;
 
   res.send({ verified });
 });

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,14 +10,17 @@
       "license": "ISC",
       "dependencies": {
         "@simplewebauthn/server": "7.0.0",
-        "@simplewebauthn/typescript-types": "^7.0.0",
+        "@simplewebauthn/typescript-types": "7.0.0",
         "base64url": "^3.0.1",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
+        "express-session": "^1.17.3",
+        "memorystore": "^1.6.7",
         "node-fetch": "^2.6.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/express-session": "^1.17.5",
         "@types/node": "^16.7.4",
         "@types/node-fetch": "^2.5.12",
         "nodemon": "^2.0.12",
@@ -271,6 +274,15 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/express-session": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.5.tgz",
+      "integrity": "sha512-l0DhkvNVfyUPEEis8fcwbd46VptfA/jmMwHfob2TfDMf3HyPLiB9mKD71LXhz5TMUobODXPD27zXSwtFQLHm+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -726,6 +738,45 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "dependencies": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -933,6 +984,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -945,6 +1005,18 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/memorystore": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.7.tgz",
+      "integrity": "sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==",
+      "dependencies": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/merge-descriptors": {
@@ -1118,6 +1190,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1163,6 +1243,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -1194,6 +1279,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1474,6 +1567,17 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -1523,6 +1627,11 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/yn": {
       "version": "3.1.1",
@@ -1736,6 +1845,15 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/express-session": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.5.tgz",
+      "integrity": "sha512-l0DhkvNVfyUPEEis8fcwbd46VptfA/jmMwHfob2TfDMf3HyPLiB9mKD71LXhz5TMUobODXPD27zXSwtFQLHm+w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/mime": {
@@ -2117,6 +2235,41 @@
         }
       }
     },
+    "express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "requires": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2264,6 +2417,15 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2274,6 +2436,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memorystore": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.7.tgz",
+      "integrity": "sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==",
+      "requires": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -2388,6 +2559,11 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2420,6 +2596,11 @@
         }
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -2443,6 +2624,11 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -2643,6 +2829,14 @@
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
     "undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -2683,6 +2877,11 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "yn": {
       "version": "3.1.1",

--- a/example/package.json
+++ b/example/package.json
@@ -16,10 +16,13 @@
     "base64url": "^3.0.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
+    "express-session": "^1.17.3",
+    "memorystore": "^1.6.7",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/express-session": "^1.17.5",
     "@types/node": "^16.7.4",
     "@types/node-fetch": "^2.5.12",
     "nodemon": "^2.0.12",


### PR DESCRIPTION
This PR adds sessions to the example app, which can be used to store the current challenge in. This provides better guidance to users trying to implement passkey flows using SimpleWebAuthn. Ideally, the passkey docs could be expanded a little to bring the general concept across - once you know how it works, it's immediately clear the ephemeral challenge will need to be stored separately, and sessions are a great fit for that. 

This will solve #103, #325, and aid users landing in discussion #321.

I hope this helps you a little, @MasterKale :)