### PR TITLE
feat/types-in-dependencies

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -30,10 +30,12 @@
     "fido",
     "umd"
   ],
+  "dependencies": {
+    "@simplewebauthn/typescript-types": "*"
+  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
-    "@simplewebauthn/typescript-types": "*",
     "rollup": "^2.52.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-version-injector": "^1.3.3"

--- a/packages/iso-webcrypto/package.json
+++ b/packages/iso-webcrypto/package.json
@@ -31,7 +31,7 @@
     "browser",
     "node"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@simplewebauthn/typescript-types": "*",
     "@types/node": "^18.11.9"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,15 +54,13 @@
     "@peculiar/asn1-rsa": "^2.3.4",
     "@peculiar/asn1-schema": "^2.3.3",
     "@peculiar/asn1-x509": "^2.3.4",
-    "@simplewebauthn/iso-webcrypto": "^7.0.1",
+    "@simplewebauthn/iso-webcrypto": "*",
+    "@simplewebauthn/typescript-types": "*",
+    "@types/debug": "^4.1.7",
+    "@types/node": "^18.11.9",
     "cbor-x": "^1.4.1",
     "cross-fetch": "^3.1.5",
     "debug": "^4.3.2"
   },
-  "gitHead": "ba039fdd5fdff87f78d3bd246e9bea5f7aa39ccb",
-  "devDependencies": {
-    "@simplewebauthn/typescript-types": "*",
-    "@types/debug": "^4.1.7",
-    "@types/node": "^18.11.9"
-  }
+  "gitHead": "ba039fdd5fdff87f78d3bd246e9bea5f7aa39ccb"
 }


### PR DESCRIPTION
This PR moves some types dependencies into **package.json** `"dependencies"`. This will primarily help pull in **@simplewebauthn/typescript-types** into more projects without developers needing to manually `npm install` it as well as **@simplewebauthn/server**.

I installed this version with the repro included in #368 and believe that this will ensure types are always available:

![Screenshot 2023-03-15 at 6 40 11 PM](https://user-images.githubusercontent.com/5166470/225487800-b36d3aec-cda9-4c72-a540-1c6c0c2de7f8.png)

Fixes #368.