### PR TITLE
fix/359-error-from-conditional-ui-abort

### DIFF
--- a/packages/browser/src/helpers/identifyAuthenticationError.ts
+++ b/packages/browser/src/helpers/identifyAuthenticationError.ts
@@ -18,7 +18,7 @@ export function identifyAuthenticationError({
   }
 
   if (error.name === 'AbortError') {
-    if (options.signal === new AbortController().signal) {
+    if (options.signal instanceof AbortSignal) {
       // https://www.w3.org/TR/webauthn-2/#sctn-createCredential (Step 16)
       return new WebAuthnError({
         message: 'Authentication ceremony was sent an abort signal',

--- a/packages/browser/src/helpers/identifyRegistrationError.ts
+++ b/packages/browser/src/helpers/identifyRegistrationError.ts
@@ -18,7 +18,7 @@ export function identifyRegistrationError({
   }
 
   if (error.name === 'AbortError') {
-    if (options.signal === new AbortController().signal) {
+    if (options.signal instanceof AbortSignal) {
       // https://www.w3.org/TR/webauthn-2/#sctn-createCredential (Step 16)
       return new WebAuthnError({
         message: 'Registration ceremony was sent an abort signal',

--- a/packages/browser/src/helpers/webAuthnAbortService.test.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.test.ts
@@ -7,7 +7,7 @@ test('should create a new abort signal every time', () => {
   expect(signal2).not.toBe(signal1);
 });
 
-test('should call abort() on existing controller when creating a new signal', () => {
+test('should call abort() with AbortError on existing controller when creating a new signal', () => {
   // Populate `.controller`
   webauthnAbortService.createNewAbortSignal();
 
@@ -19,4 +19,9 @@ test('should call abort() on existing controller when creating a new signal', ()
   // Generate a new signal, which should call `abort()` on the existing controller
   webauthnAbortService.createNewAbortSignal();
   expect(abortSpy).toHaveBeenCalledTimes(1);
+
+  // Make sure we raise an AbortError so it can be detected correctly
+  const abortReason = abortSpy.mock.calls[0][0];
+  expect(abortReason).toBeInstanceOf(Error);
+  expect(abortReason.name).toEqual('AbortError');
 });

--- a/packages/browser/src/helpers/webAuthnAbortService.ts
+++ b/packages/browser/src/helpers/webAuthnAbortService.ts
@@ -12,7 +12,9 @@ class WebAuthnAbortService {
   createNewAbortSignal() {
     // Abort any existing calls to navigator.credentials.create() or navigator.credentials.get()
     if (this.controller) {
-      this.controller.abort('Cancelling existing WebAuthn API call for new one');
+      const abortError = new Error('Cancelling existing WebAuthn API call for new one');
+      abortError.name = 'AbortError';
+      this.controller.abort(abortError);
     }
 
     const newController = new AbortController();


### PR DESCRIPTION
This PR updates `WebAuthnAbortService` to abort existing WebAuthn calls with an `AbortError` instead of a `string`. This allows for error handlers on `startAuthentication()` to handle the cancelling of Conditional UI with the same logic that would handle the user cancelling out of the WebAuthn modal experience.

This also fixes accidentally broken `AbortError` error identification during both registration and authentication, so that the enhanced error codes introduced in #367 can properly identify the throwing of `AbortError` too:

![Screenshot 2023-03-15 at 10 52 26 PM](https://user-images.githubusercontent.com/5166470/225527108-a88aec99-7b7a-4ab5-b48c-410e72be9aa7.png)

Fixes #359.