### PR TITLE
fix/379-update-example-fido-current-challenge

### DIFF
--- a/example/fido-conformance.ts
+++ b/example/fido-conformance.ts
@@ -144,6 +144,9 @@ fidoConformanceRouter.post('/attestation/options', (req, res) => {
 
   req.session.currentChallenge = opts.challenge;
 
+  // Only return the extensions we're given
+  opts.extensions = extensions;
+
   return res.send({
     ...opts,
     status: 'ok',

--- a/example/fido-conformance.ts
+++ b/example/fido-conformance.ts
@@ -140,7 +140,7 @@ fidoConformanceRouter.post('/attestation/options', (req, res) => {
     supportedAlgorithmIDs,
   });
 
-  user.currentChallenge = opts.challenge;
+  req.session.currentChallenge = opts.challenge;
 
   return res.send({
     ...opts,
@@ -157,7 +157,7 @@ fidoConformanceRouter.post('/attestation/result', async (req, res) => {
 
   const user = inMemoryUserDeviceDB[`${loggedInUsername}`];
 
-  const expectedChallenge = user.currentChallenge;
+  const expectedChallenge = req.session.currentChallenge;
 
   let verification;
   try {
@@ -222,7 +222,7 @@ fidoConformanceRouter.post('/assertion/options', (req, res) => {
     })),
   });
 
-  user.currentChallenge = opts.challenge;
+  req.session.currentChallenge = opts.challenge;
   user.currentAuthenticationUserVerification = userVerification;
 
   return res.send({
@@ -239,7 +239,7 @@ fidoConformanceRouter.post('/assertion/result', async (req, res) => {
   const user = inMemoryUserDeviceDB[`${loggedInUsername}`];
 
   // Pull up values specified when generation authentication options
-  const expectedChallenge = user.currentChallenge;
+  const expectedChallenge = req.session.currentChallenge;
   const userVerification = user.currentAuthenticationUserVerification;
 
   if (!id) {

--- a/example/fido-conformance.ts
+++ b/example/fido-conformance.ts
@@ -57,8 +57,10 @@ try {
 
 /**
  * Initialize MetadataService with Conformance Testing-specific statements.
+ *
+ * (Grabbed this URL from the POST made on https://mds3.fido.tools/ when you submit your site's URL)
  */
-fetch('https://mds3.certinfra.fidoalliance.org/getEndpoints', {
+fetch('https://mds3.fido.tools/getEndpoints', {
   method: 'POST',
   body: JSON.stringify({ endpoint: `${expectedOrigin}${fidoRouteSuffix}` }),
   headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
This PR fixes example server build issues related to the FIDO routes not using `req.session` to store `currentChallenge` (see #326).

Fixes #379.