### PR TITLE
395-support-typescript-4.0

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -4,6 +4,7 @@
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
 [![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/server)
 ![node-lts (scoped)](https://img.shields.io/node/v/@simplewebauthn/server?style=for-the-badge&logo=Node.js)
+![typescript minimum version 4.3](https://img.shields.io/badge/TypeScript-%3E%3D_4.3-3178C6?style=for-the-badge&logo=TypeScript)
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -4,7 +4,7 @@
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
 [![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/server)
 ![node-lts (scoped)](https://img.shields.io/node/v/@simplewebauthn/server?style=for-the-badge&logo=Node.js)
-![typescript minimum version 4.3](https://img.shields.io/badge/TypeScript-%3E%3D_4.3-3178C6?style=for-the-badge&logo=TypeScript)
+![typescript minimum version 4.4](https://img.shields.io/badge/TypeScript-%3E%3D_4.4-3178C6?style=for-the-badge&logo=TypeScript)
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/packages/server/src/helpers/decodeAttestationObject.ts
+++ b/packages/server/src/helpers/decodeAttestationObject.ts
@@ -37,5 +37,5 @@ export type AttestationStatement = {
   get(key: 'certInfo'): Uint8Array | undefined;
   get(key: 'pubArea'): Uint8Array | undefined;
   // `Map` properties
-  get size(): number;
+  readonly size: number;
 };


### PR DESCRIPTION
This PR updates the `AttestationStatement.size` type to use syntax that is friendlier for older versions of TypeScript, including TypeScript 4.0.

This PR also defines this project's **minimum officially supported TypeScript of Version 4.4+**. From here on no further efforts will be taken to support anything older than this.

Fixes #395.