### PR TITLE
feat/smart-card-transport

### DIFF
--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -11,7 +11,7 @@ export function toPublicKeyCredentialDescriptor(
     ...descriptor,
     id: base64URLStringToBuffer(id),
     /**
-     * `descriptor.transports` is an array of our `AuthenticatorTransport` that includes newer
+     * `descriptor.transports` is an array of our `AuthenticatorTransportFuture` that includes newer
      * transports that TypeScript's DOM lib is ignorant of. Convince TS that our list of transports
      * are fine to pass to WebAuthn since browsers will recognize the new value.
      */

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -180,7 +180,15 @@ export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAtt
  * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
  * know about it (sometime after 4.6.3)
  */
-export type AuthenticatorTransportFuture = 'ble' | 'internal' | 'nfc' | 'usb' | 'cable' | 'hybrid';
+export type AuthenticatorTransportFuture =
+  'ble'
+  | 'cable'
+  | 'hybrid'
+  | 'internal'
+  | 'nfc'
+  | 'smart-card'
+  | 'usb'
+  ;
 
 /**
  * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest


### PR DESCRIPTION
This PR adds the new "smart-card" transport that Safari has added support for in the WebAuthn spec L3 draft:

https://github.com/w3c/webauthn/pull/1865

I also sorted the transports in "canonical order" (alphabetically) because the spec makes mention of them being returned in that order, and because I felt like it.

Fixes #374.