### PR TITLE
feat/json-type-updates

### DIFF
--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -250,6 +250,33 @@ test('should return authenticatorAttachment if present', async () => {
   expect(response.authenticatorAttachment).toEqual('cross-platform');
 });
 
+test('should return convenience values if present', async () => {
+  /**
+   * I call them "convenience values" because the getters for public key algorithm,
+   * public key bytes, and authenticator data are alternative ways to access information
+   * that's already buried in the response.
+   */
+  // Mock extension return values from authenticator
+  mockNavigatorCreate.mockImplementation((): Promise<any> => {
+    return new Promise(resolve => {
+      resolve({
+        response: {
+          getPublicKeyAlgorithm: () => 777,
+          getPublicKey: () => new Uint8Array([0, 0, 0, 0]).buffer,
+          getAuthenticatorData: () => new Uint8Array([0, 0, 0, 0]).buffer,
+        },
+        getClientExtensionResults: () => { },
+      });
+    });
+  });
+
+  const response = await startRegistration(goodOpts1);
+
+  expect(response.response.publicKeyAlgorithm).toEqual(777);
+  expect(response.response.publicKey).toEqual('AAAAAA');
+  expect(response.response.authenticatorData).toEqual('AAAAAA');
+});
+
 describe('WebAuthnError', () => {
   describe('AbortError', () => {
     const AbortError = generateCustomError('AbortError');

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -250,7 +250,7 @@ test('should return authenticatorAttachment if present', async () => {
   expect(response.authenticatorAttachment).toEqual('cross-platform');
 });
 
-test('should return convenience values if present', async () => {
+test('should return convenience values if getters present', async () => {
   /**
    * I call them "convenience values" because the getters for public key algorithm,
    * public key bytes, and authenticator data are alternative ways to access information
@@ -275,6 +275,29 @@ test('should return convenience values if present', async () => {
   expect(response.response.publicKeyAlgorithm).toEqual(777);
   expect(response.response.publicKey).toEqual('AAAAAA');
   expect(response.response.authenticatorData).toEqual('AAAAAA');
+});
+
+test('should not return convenience values if getters missing', async () => {
+  /**
+   * I call them "convenience values" because the getters for public key algorithm,
+   * public key bytes, and authenticator data are alternative ways to access information
+   * that's already buried in the response.
+   */
+  // Mock extension return values from authenticator
+  mockNavigatorCreate.mockImplementation((): Promise<any> => {
+    return new Promise(resolve => {
+      resolve({
+        response: {},
+        getClientExtensionResults: () => { },
+      });
+    });
+  });
+
+  const response = await startRegistration(goodOpts1);
+
+  expect(response.response.publicKeyAlgorithm).toBeUndefined();
+  expect(response.response.publicKey).toBeUndefined();
+  expect(response.response.authenticatorData).toBeUndefined();
 });
 
 describe('WebAuthnError', () => {

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -64,6 +64,26 @@ export async function startRegistration(
     transports = response.getTransports();
   }
 
+  // L3 says this is required, but browser and webview support are still not guaranteed.
+  let responsePublicKeyAlgorithm: number | undefined = undefined;
+  if (typeof response.getPublicKeyAlgorithm === 'function') {
+    responsePublicKeyAlgorithm = response.getPublicKeyAlgorithm();
+  }
+
+  let responsePublicKey: string | undefined = undefined;
+  if (typeof response.getPublicKey === 'function') {
+    const _publicKey = response.getPublicKey();
+    if (_publicKey !== null) {
+      responsePublicKey = bufferToBase64URLString(_publicKey);
+    }
+  }
+
+  // L3 says this is required, but browser and webview support are still not guaranteed.
+  let responseAuthenticatorData: string | undefined;
+  if (typeof response.getAuthenticatorData === 'function') {
+    responseAuthenticatorData = bufferToBase64URLString(response.getAuthenticatorData());
+  }
+
   return {
     id,
     rawId: bufferToBase64URLString(rawId),
@@ -71,6 +91,9 @@ export async function startRegistration(
       attestationObject: bufferToBase64URLString(response.attestationObject),
       clientDataJSON: bufferToBase64URLString(response.clientDataJSON),
       transports,
+      publicKeyAlgorithm: responsePublicKeyAlgorithm,
+      publicKey: responsePublicKey,
+      authenticatorData: responseAuthenticatorData,
     },
     type,
     clientExtensionResults: credential.getClientExtensionResults(),

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -133,9 +133,9 @@ export interface AuthenticatorAttestationResponseJSON {
   authenticatorData?: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   transports?: AuthenticatorTransportFuture[];
-  publicKey?: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   publicKeyAlgorithm?: COSEAlgorithmIdentifier;
+  publicKey?: Base64URLString;
 }
 
 /**

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -19,6 +19,7 @@ import type {
   AuthenticatorAttachment,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialRequestOptions,
+  COSEAlgorithmIdentifier,
 } from './dom';
 
 export * from './dom';
@@ -129,7 +130,12 @@ export interface AuthenticatorAttestationResponseJSON {
   clientDataJSON: Base64URLString;
   attestationObject: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
+  authenticatorData?: Base64URLString;
+  // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   transports?: AuthenticatorTransportFuture[];
+  publicKey?: Base64URLString;
+  // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
+  publicKeyAlgorithm?: COSEAlgorithmIdentifier;
 }
 
 /**


### PR DESCRIPTION
I just went through all the types `JSON` types in **@simplewebauthn/typescript-types** and matched them against the [latest L3 draft](https://w3c.github.io/webauthn/) and almost everything looks good:

![Screenshot 2023-06-25 at 9 05 43 AM](https://github.com/MasterKale/SimpleWebAuthn/assets/5166470/e0d81679-9166-4254-9488-f6e7f59a4217)

...Except for missing additions of the "convenience values" `publicKeyAlgorithm`, `publicKey`, and `authenticatorData` on `AuthenticatorAttestationResponseJSON`. These values come from the correspondingly-named [`get...()` methods on `AuthenticatorAttestationResponse`](https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse).

The types deviate a bit from what's in L3 because 1) L3 isn't the Recommendation yet, and 2) browser compatibility is still a little spotty (MDN says Firefox doesn't really support the getters):

- [`getAuthenticatorData()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getAuthenticatorData)
- [`getPublicKeyAlgorithm()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getPublicKeyAlgorithm)
- [`getPublicKey()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getPublicKey)

This PR will return the values in the output from **browser**'s `startRegistration()` when their corresponding getter methods are available.

Fixes #384.