### PR TITLE
Replace base64url with isoBase64URL

### DIFF
--- a/example/fido-conformance.ts
+++ b/example/fido-conformance.ts
@@ -2,7 +2,6 @@
 import fs from 'fs';
 import express from 'express';
 import fetch from 'node-fetch';
-import base64url from 'base64url';
 
 import {
   generateRegistrationOptions,
@@ -13,7 +12,7 @@ import {
   MetadataStatement,
   SettingsService,
 } from '@simplewebauthn/server';
-import { isoUint8Array } from '@simplewebauthn/server/helpers';
+import { isoBase64URL, isoUint8Array } from '@simplewebauthn/server/helpers';
 import {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -253,7 +252,7 @@ fidoConformanceRouter.post('/assertion/result', async (req, res) => {
     return res.status(400).send({ errorMessage: msg });
   }
 
-  const credIDBuffer = base64url.toBuffer(id);
+  const credIDBuffer = isoBase64URL.toBuffer(id);
   const existingDevice = user.devices.find(device => isoUint8Array.areEqual(device.credentialID, credIDBuffer));
 
   if (!existingDevice) {

--- a/example/index.ts
+++ b/example/index.ts
@@ -13,7 +13,6 @@ import express from 'express';
 import session from 'express-session';
 import memoryStore from 'memorystore';
 import dotenv from 'dotenv';
-import base64url from 'base64url';
 
 dotenv.config();
 
@@ -25,7 +24,7 @@ import {
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
 } from '@simplewebauthn/server';
-import { isoUint8Array } from '@simplewebauthn/server/helpers';
+import { isoBase64URL, isoUint8Array } from '@simplewebauthn/server/helpers';
 import type {
   GenerateRegistrationOptionsOpts,
   GenerateAuthenticationOptionsOpts,
@@ -247,7 +246,7 @@ app.post('/verify-authentication', async (req, res) => {
   const expectedChallenge = req.session.currentChallenge;
 
   let dbAuthenticator;
-  const bodyCredIDBuffer = base64url.toBuffer(body.rawId);
+  const bodyCredIDBuffer = isoBase64URL.toBuffer(body.rawId);
   // "Query the DB" here for an authenticator matching `credentialID`
   for (const dev of user.devices) {
     if (isoUint8Array.areEqual(dev.credentialID, bodyCredIDBuffer)) {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@simplewebauthn/server": "7.2.0",
-        "base64url": "^3.0.1",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-session": "^1.17.3",
@@ -445,14 +444,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2032,11 +2023,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "@simplewebauthn/server": "7.2.0",
-    "base64url": "^3.0.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-session": "^1.17.3",


### PR DESCRIPTION
Replacement and deletion of base64url dependency in favor of already existing isoBase64URL helper.

Tested with no issues apparent, as per @MasterKale request in the issue below.

Fixes https://github.com/MasterKale/SimpleWebAuthn/issues/422