### PR TITLE
fix/405-browser-safari-13-1-catalina

### DIFF
--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2021",
     "module": "ESNext",
     "moduleResolution": "node",
     "lib": [


### PR DESCRIPTION
This PR drops **browser**'s compilation target down from `"ES2022"` to `"ES2021"`. This will allow for projects like Vite with a lower compilation target to emit websites that can handle a browser like **Safari 13.1 in macOS Catalina** that hadn't yet gained knowledge of things like [public class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields).

Fixes #405.