### PR TITLE
Allow expectedChallenge to return a Promise

### DIFF
--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -15,7 +15,7 @@ import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
 
 export type VerifyAuthenticationResponseOpts = {
   response: AuthenticationResponseJSON;
-  expectedChallenge: string | ((challenge: string) => boolean);
+  expectedChallenge: string | ((challenge: string) => boolean | Promise<boolean>);
   expectedOrigin: string | string[];
   expectedRPID: string | string[];
   authenticator: AuthenticatorDevice;
@@ -94,7 +94,7 @@ export async function verifyAuthenticationResponse(
 
   // Ensure the device provided the challenge we gave it
   if (typeof expectedChallenge === 'function') {
-    if (!expectedChallenge(challenge)) {
+    if (!(await expectedChallenge(challenge))) {
       throw new Error(
         `Custom challenge verifier returned false for registration response challenge "${challenge}"`,
       );

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -750,6 +750,71 @@ Deno.test('should fail verification if custom challenge verifier returns false',
   );
 });
 
+Deno.test('should pass verification if custom challenge verifier returns a Promise that resolves with true', async () => {
+  const verification = await verifyRegistrationResponse({
+    response: {
+      id:
+        'AUywDsPYEOoucI3-o-jB1J6Kt6QAxLMa1WwFKj1bNi4pAakWAsZX-pJ4gAeDmocL7SXnl8vzUfLkfrOGIVmds1RhjU1DYIWlxcGhAA',
+      rawId:
+        'AUywDsPYEOoucI3-o-jB1J6Kt6QAxLMa1WwFKj1bNi4pAakWAsZX-pJ4gAeDmocL7SXnl8vzUfLkfrOGIVmds1RhjU1DYIWlxcGhAA',
+      response: {
+        attestationObject:
+          'o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEcwRQIhAPgoy3sxIeUvN9Mo8twyIQb9hXDHxQ2urIaEq14u6vNHAiB8ltlCippsMIIsh6AqMoZlUH_BH0bXT1xsN2zKoCEy72hhdXRoRGF0YVjQSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFYfWYqK3OAAI1vMYKZIsLJfHwVQMATAFMsA7D2BDqLnCN_qPowdSeirekAMSzGtVsBSo9WzYuKQGpFgLGV_qSeIAHg5qHC-0l55fL81Hy5H6zhiFZnbNUYY1NQ2CFpcXBoQClAQIDJiABIVggPzMMB0nPKu9zvu6tvvyaP7MlGKJi4zazYQw5kyCjGykiWCCyHxcnMCwcj4llYwRY-MedgOCQzcz_TgKeabY4yFQyrA',
+        clientDataJSON:
+          'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiZXlKaFkzUjFZV3hEYUdGc2JHVnVaMlVpT2lKNFVuTlpaRU5SZGpWWFdrOXhiWGhTWldsYWJEWkRPWEUxVTJaeVdtNWxOR3hPVTNJNVVWWjBVR2xuSWl3aVlYSmlhWFJ5WVhKNVJHRjBZU0k2SW1GeVltbDBjbUZ5ZVVSaGRHRkdiM0pUYVdkdWFXNW5JbjAiLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwMDAiLCJjcm9zc09yaWdpbiI6ZmFsc2V9',
+        transports: ['internal'],
+      },
+      type: 'public-key',
+      clientExtensionResults: {},
+    },
+    expectedChallenge: (challenge: string) => {
+      const parsedChallenge: {
+        actualChallenge: string;
+        arbitraryData: string;
+      } = JSON.parse(
+        isoBase64URL.toString(challenge),
+      );
+      return Promise.resolve(
+        parsedChallenge.actualChallenge ===
+          'xRsYdCQv5WZOqmxReiZl6C9q5SfrZne4lNSr9QVtPig',
+      );
+    },
+    expectedOrigin: 'http://localhost:8000',
+    expectedRPID: 'localhost',
+  });
+
+  assert(verification.verified);
+});
+
+Deno.test('should fail verification if custom challenge verifier returns a Promise that resolves with false', async () => {
+  await assertRejects(
+    () =>
+      verifyRegistrationResponse({
+        response: attestationNone,
+        expectedChallenge: (challenge: string) =>
+          Promise.resolve(challenge === 'thisWillneverMatch'),
+        expectedOrigin: 'https://dev.dontneeda.pw',
+        expectedRPID: 'dev.dontneeda.pw',
+      }),
+    Error,
+    'Custom challenge verifier returned false',
+  );
+});
+
+Deno.test('should fail verification if custom challenge verifier returns a Promise that rejects', async () => {
+  await assertRejects(
+    () =>
+      verifyRegistrationResponse({
+        response: attestationNone,
+        expectedChallenge: (challenge: string) => Promise.reject(new Error('rejected')),
+        expectedOrigin: 'https://dev.dontneeda.pw',
+        expectedRPID: 'dev.dontneeda.pw',
+      }),
+    Error,
+    'rejected',
+  );
+});
+
 Deno.test('should return credential backup info', async () => {
   const verification = await verifyRegistrationResponse({
     response: attestationNone,

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -30,7 +30,7 @@ import { verifyAttestationApple } from './verifications/verifyAttestationApple.t
 
 export type VerifyRegistrationResponseOpts = {
   response: RegistrationResponseJSON;
-  expectedChallenge: string | ((challenge: string) => boolean);
+  expectedChallenge: string | ((challenge: string) => boolean | Promise<boolean>);
   expectedOrigin: string | string[];
   expectedRPID?: string | string[];
   requireUserVerification?: boolean;
@@ -95,7 +95,7 @@ export async function verifyRegistrationResponse(
 
   // Ensure the device provided the challenge we gave it
   if (typeof expectedChallenge === 'function') {
-    if (!expectedChallenge(challenge)) {
+    if (!(await expectedChallenge(challenge))) {
       throw new Error(
         `Custom challenge verifier returned false for registration response challenge "${challenge}"`,
       );


### PR DESCRIPTION
This PR allows `verifyAuthenticationResponse` and `verifyRegistrationResponse` to accept `expectedChallenge` properties of their `options` parameter to be Promise returning functions. This allows code like this:

```ts
async function customAsyncVerification(challenge: string): Promise<boolean> {
   ...
}

const isVerified = await verifyAuthenticationResponse({
  ...
  expectedChallenge: customAsyncVerification,
  ...
});
```

Three tests per verification function have been added:
1. Checks for Promises that resolve with `true`.
2. Checks for Promises that resolve with `false`.
3. Checks for Promises that reject.

Fixes #431