### PR TITLE
fix/430-make-debug-logging-noop

### DIFF
--- a/packages/server/build_npm.ts
+++ b/packages/server/build_npm.ts
@@ -74,14 +74,6 @@ await build({
       name: 'cbor-x',
       version: '^1.5.2',
     },
-    'https://esm.sh/debug@4.3.4': {
-      name: 'debug',
-      version: '^4.3.4',
-    },
-    'https://esm.sh/@types/debug@4.1.8': {
-      name: '@types/debug',
-      version: '^4.1.8',
-    },
     'https://esm.sh/cross-fetch@4.0.0': {
       name: 'cross-fetch',
       version: '^4.0.0',

--- a/packages/server/src/deps.ts
+++ b/packages/server/src/deps.ts
@@ -26,10 +26,6 @@ export { default as base64 } from 'https://deno.land/x/b64@1.1.27/src/base64.js'
 // cross-fetch
 export { fetch as crossFetch } from 'https://esm.sh/cross-fetch@4.0.0';
 
-// debug
-export { default as debug } from 'https://esm.sh/debug@4.3.4';
-export type { Debugger } from 'https://esm.sh/@types/debug@4.1.8';
-
 // @peculiar libraries
 export { AsnParser, AsnSerializer } from 'https://esm.sh/@peculiar/asn1-schema@2.3.6';
 export {

--- a/packages/server/src/helpers/logging.ts
+++ b/packages/server/src/helpers/logging.ts
@@ -1,6 +1,6 @@
-import { debug, Debugger } from '../deps.ts';
+// import { debug, Debugger } from '../deps.ts';
 
-const defaultLogger = debug('SimpleWebAuthn');
+// const defaultLogger = debug('SimpleWebAuthn');
 
 /**
  * Generate an instance of a `debug` logger that extends off of the "simplewebauthn" namespace for
@@ -16,6 +16,7 @@ const defaultLogger = debug('SimpleWebAuthn');
  * log('hello'); // simplewebauthn:mds hello +0ms
  * ```
  */
-export function getLogger(name: string): Debugger {
-  return defaultLogger.extend(name);
+export function getLogger(_name: string): (message: string, ..._rest: unknown[]) => void {
+  // This is a noop for now while I search for a better debug logger technique
+  return (_message, ..._rest) => {};
 }


### PR DESCRIPTION
I'm disabling logging output for now while I investigate an alternative library to https://www.npmjs.com/package/debug. The fact that it requires @types/debug to also be installed is creating this catch-22 with dnt, specifically the `Debugger` type that comes from @types/debug.

In a Node project you'd re-export it like this after installing @types/debug:

```
export { Debugger, default as debug } from 'debug';
```

But Deno requires you to import `Debugger` from @types/debug specifically:

```
export { default as debug } from 'https://esm.sh/debug@4.3.4';
export type { Debugger } from 'https://esm.sh/@types/debug@4.1.8';
```

Unfortunately after dnt builds the project, trying to build a TypeScript project with `tsc` results in an error like the one reported in Issue #430:

```
node_modules/@simplewebauthn/server/script/deps.d.ts:6:31 - error TS6137: Cannot
import type declaration files. Consider importing 'debug' instead of '@types/debug'.

6 export type { Debugger } from '@types/debug';
                                ~~~~~~~~~~~~~~
```

Disabling logging now will give me time to research an alternative.