### PR TITLE
Add `expectedType` for verifyAuthenticationResponse  and verifyRegistrationResponse

### DIFF
--- a/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.test.ts
@@ -335,6 +335,40 @@ Deno.test('should throw an error if RP ID not in list of possible RP IDs', async
   );
 });
 
+Deno.test('should throw an error if type not the expected type', async () => {
+  await assertRejects(
+    () =>
+      verifyAuthenticationResponse({
+        response: assertionResponse,
+        expectedChallenge: assertionChallenge,
+        expectedOrigin: assertionOrigin,
+        // assertionResponse contains webauthn.get, this should produce an error
+        expectedType: 'payment.get',
+        expectedRPID: 'localhost',
+        authenticator: authenticator,
+      }),
+    Error,
+    'Unexpected authentication response type',
+  );
+});
+
+Deno.test('should throw an error if type not in list of expected types', async () => {
+  await assertRejects(
+    () =>
+      verifyAuthenticationResponse({
+        response: assertionResponse,
+        expectedChallenge: assertionChallenge,
+        expectedOrigin: assertionOrigin,
+        // assertionResponse contains webauthn.get, this should produce an error
+        expectedType: ['payment.get', 'something.get'],
+        expectedRPID: 'localhost',
+        authenticator: authenticator,
+      }),
+    Error,
+    'Unexpected authentication response type',
+  );
+});
+
 Deno.test('should pass verification if custom challenge verifier returns true', async () => {
   const verification = await verifyAuthenticationResponse({
     response: {

--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -18,6 +18,7 @@ export type VerifyAuthenticationResponseOpts = {
   expectedChallenge: string | ((challenge: string) => boolean | Promise<boolean>);
   expectedOrigin: string | string[];
   expectedRPID: string | string[];
+  expectedType?: string | string[];
   authenticator: AuthenticatorDevice;
   requireUserVerification?: boolean;
   advancedFIDOConfig?: {
@@ -52,6 +53,7 @@ export async function verifyAuthenticationResponse(
     expectedChallenge,
     expectedOrigin,
     expectedRPID,
+    expectedType,
     authenticator,
     requireUserVerification = true,
     advancedFIDOConfig,
@@ -88,7 +90,16 @@ export async function verifyAuthenticationResponse(
   const { type, origin, challenge, tokenBinding } = clientDataJSON;
 
   // Make sure we're handling an authentication
-  if (type !== 'webauthn.get') {
+  if (Array.isArray(expectedType)) {
+    if (!expectedType.includes(type)) {
+      const joinedExpectedType = expectedType.join(', ');
+      throw new Error(`Unexpected authentication response type "${type}", expected one of: ${joinedExpectedType}`);
+    }
+  } else if (expectedType) {
+    if (type !== expectedType) {
+      throw new Error(`Unexpected authentication response type "${type}", expected "${expectedType}"`);
+    }
+  } else if (type !== 'webauthn.get') {
     throw new Error(`Unexpected authentication response type: ${type}`);
   }
 

--- a/packages/server/src/authentication/verifyAuthenticationResponse.ts
+++ b/packages/server/src/authentication/verifyAuthenticationResponse.ts
@@ -36,6 +36,7 @@ export type VerifyAuthenticationResponseOpts = {
  * `generateAuthenticationOptions()`
  * @param expectedOrigin Website URL (or array of URLs) that the registration should have occurred on
  * @param expectedRPID RP ID (or array of IDs) that was specified in the registration options
+ * @param expectedType (Optional) The response type expected ('webauthn.get')
  * @param authenticator An internal {@link AuthenticatorDevice} matching the credential's ID
  * @param requireUserVerification (Optional) Enforce user verification by the authenticator
  * (via PIN, fingerprint, etc...)

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -33,6 +33,7 @@ export type VerifyRegistrationResponseOpts = {
   expectedChallenge: string | ((challenge: string) => boolean | Promise<boolean>);
   expectedOrigin: string | string[];
   expectedRPID?: string | string[];
+  expectedType?: string | string[];
   requireUserVerification?: boolean;
   supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
 };
@@ -47,6 +48,7 @@ export type VerifyRegistrationResponseOpts = {
  * `generateRegistrationOptions()`
  * @param expectedOrigin Website URL (or array of URLs) that the registration should have occurred on
  * @param expectedRPID RP ID (or array of IDs) that was specified in the registration options
+ * @param expectedType (Optional) The response type expected ('webauthn.create')
  * @param requireUserVerification (Optional) Enforce user verification by the authenticator
  * (via PIN, fingerprint, etc...)
  * @param supportedAlgorithmIDs Array of numeric COSE algorithm identifiers supported for
@@ -60,6 +62,7 @@ export async function verifyRegistrationResponse(
     expectedChallenge,
     expectedOrigin,
     expectedRPID,
+    expectedType,
     requireUserVerification = true,
     supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers,
   } = options;
@@ -89,7 +92,16 @@ export async function verifyRegistrationResponse(
   const { type, origin, challenge, tokenBinding } = clientDataJSON;
 
   // Make sure we're handling an registration
-  if (type !== 'webauthn.create') {
+  if (Array.isArray(expectedType)) {
+    if (!expectedType.includes(type)) {
+      const joinedExpectedType = expectedType.join(', ');
+      throw new Error(`Unexpected authentication response type "${type}", expected one of: ${joinedExpectedType}`);
+    }
+  } else if (expectedType) {
+    if (type !== expectedType) {
+      throw new Error(`Unexpected authentication response type "${type}", expected "${expectedType}"`);
+    }
+  } else if (type !== 'webauthn.create') {
     throw new Error(`Unexpected registration response type: ${type}`);
   }
 

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -95,11 +95,11 @@ export async function verifyRegistrationResponse(
   if (Array.isArray(expectedType)) {
     if (!expectedType.includes(type)) {
       const joinedExpectedType = expectedType.join(', ');
-      throw new Error(`Unexpected authentication response type "${type}", expected one of: ${joinedExpectedType}`);
+      throw new Error(`Unexpected registration response type "${type}", expected one of: ${joinedExpectedType}`);
     }
   } else if (expectedType) {
     if (type !== expectedType) {
-      throw new Error(`Unexpected authentication response type "${type}", expected "${expectedType}"`);
+      throw new Error(`Unexpected registration response type "${type}", expected "${expectedType}"`);
     }
   } else if (type !== 'webauthn.create') {
     throw new Error(`Unexpected registration response type: ${type}`);


### PR DESCRIPTION
This enables the functionality for authentication types like [`payment.get`](https://www.w3.org/TR/secure-payment-confirmation/#client-extension-processing-authentication)

This would be used in this code right here: https://github.com/opennetwork/logistics/blob/7a305ea1a51d2276e2b77ebbc8be42e80c361893/src/listen/auth/webauthn.ts#L593C9-L604C12

```typescript
const {verified, authenticationInfo} = await verifyAuthenticationResponse({
  response: payment.details,
  expectedChallenge,
  expectedOrigin: WEBAUTHN_RP_ORIGIN || origin,
  expectedRPID: WEBAUTHN_RP_ID || hostname,
  expectedType: "payment.get",
  authenticator: {
    credentialID: new Uint8Array(toArrayBuffer(found.credentialId, true)),
    credentialPublicKey: new Uint8Array(toArrayBuffer(found.credentialPublicKey, true)),
    transports: found.authenticatorTransports,
    counter: found.credentialCounter ?? 0
  }
});
``` 

Related to https://github.com/MasterKale/SimpleWebAuthn/discussions/402

This isn't complete support for secure payment confirmation, but its the only runtime level change needed. Some types need to be widened to allow additional extensions. 