### PR TITLE
fix: hide errors when get-public-key is not supported

### DIFF
--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -67,23 +67,29 @@ export async function startRegistration(
   // L3 says this is required, but browser and webview support are still not guaranteed.
   let responsePublicKeyAlgorithm: number | undefined = undefined;
   if (typeof response.getPublicKeyAlgorithm === 'function') {
-    responsePublicKeyAlgorithm = response.getPublicKeyAlgorithm();
+    try {
+      responsePublicKeyAlgorithm = response.getPublicKeyAlgorithm();
+    } catch (err) {}
   }
-
+  
   let responsePublicKey: string | undefined = undefined;
   if (typeof response.getPublicKey === 'function') {
-    const _publicKey = response.getPublicKey();
-    if (_publicKey !== null) {
-      responsePublicKey = bufferToBase64URLString(_publicKey);
-    }
+    try {
+      const _publicKey = response.getPublicKey();
+      if (_publicKey !== null) {
+        responsePublicKey = bufferToBase64URLString(_publicKey);
+      }
+    } catch (err) {}
   }
 
   // L3 says this is required, but browser and webview support are still not guaranteed.
   let responseAuthenticatorData: string | undefined;
   if (typeof response.getAuthenticatorData === 'function') {
-    responseAuthenticatorData = bufferToBase64URLString(
-      response.getAuthenticatorData(),
-    );
+    try {
+      responseAuthenticatorData = bufferToBase64URLString(
+        response.getAuthenticatorData(),
+      );
+    } catch (err) {}
   }
 
   return {


### PR DESCRIPTION
## Changes

Methods `getPublicKey` and `getPublicKeyAlgorithm` may still return `function type` in unsupported environments and only throw an error when called, for this reason we manually ignore this error.

- Passed the test in the local sample project;
- No side effects seen in the complete registration, auth, etc. process;
- Tested to be able to support 1Password and save data in 1Password (not other devices).

### Refs

- #438 