### PR TITLE
fix/438-handle-bad-publickey-getters

### DIFF
--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -67,23 +67,35 @@ export async function startRegistration(
   // L3 says this is required, but browser and webview support are still not guaranteed.
   let responsePublicKeyAlgorithm: number | undefined = undefined;
   if (typeof response.getPublicKeyAlgorithm === 'function') {
-    responsePublicKeyAlgorithm = response.getPublicKeyAlgorithm();
+    try {
+      responsePublicKeyAlgorithm = response.getPublicKeyAlgorithm();
+    } catch (error) {
+      // pass
+    }
   }
 
   let responsePublicKey: string | undefined = undefined;
   if (typeof response.getPublicKey === 'function') {
-    const _publicKey = response.getPublicKey();
-    if (_publicKey !== null) {
-      responsePublicKey = bufferToBase64URLString(_publicKey);
+    try {
+      const _publicKey = response.getPublicKey();
+      if (_publicKey !== null) {
+        responsePublicKey = bufferToBase64URLString(_publicKey);
+      }
+    } catch (error) {
+      // pass
     }
   }
 
   // L3 says this is required, but browser and webview support are still not guaranteed.
   let responseAuthenticatorData: string | undefined;
   if (typeof response.getAuthenticatorData === 'function') {
-    responseAuthenticatorData = bufferToBase64URLString(
-      response.getAuthenticatorData(),
-    );
+    try {
+      responseAuthenticatorData = bufferToBase64URLString(
+        response.getAuthenticatorData(),
+      );
+    } catch (error) {
+      // pass
+    }
   }
 
   return {


### PR DESCRIPTION
This PR updates **browser**'s `startRegistration()` method to be more resilient when attempting to call the following methods:

- `getPublicKeyAlgorithm()`
- `getPublicKey()`
- `getAuthenticatorData()`

This should allow `startRegistration()` to support responses generated by the 1Password browser extension v2.15.1+.

Fixes #438.

Shout out to @unix for proposing the initial version of this PR with #439. This PR supersedes that one, but I'm grateful all the same 🙇 