### PR TITLE
feat/export-base64url-helpers-browser

### DIFF
--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -15,3 +15,11 @@ test('should export method `browserSupportsWebAuthn`', () => {
 test('should export method `platformAuthenticatorIsAvailable`', () => {
   expect(index.browserSupportsWebAuthn).toBeDefined();
 });
+
+test('should export method `base64URLStringToBuffer`', () => {
+  expect(index.base64URLStringToBuffer).toBeDefined();
+});
+
+test('should export method `bufferToBase64URLString`', () => {
+  expect(index.bufferToBase64URLString).toBeDefined();
+});

--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -12,8 +12,12 @@ test('should export method `browserSupportsWebAuthn`', () => {
   expect(index.browserSupportsWebAuthn).toBeDefined();
 });
 
+test('should export method `browserSupportsWebAuthnAutofill`', () => {
+  expect(index.browserSupportsWebAuthnAutofill).toBeDefined();
+});
+
 test('should export method `platformAuthenticatorIsAvailable`', () => {
-  expect(index.browserSupportsWebAuthn).toBeDefined();
+  expect(index.platformAuthenticatorIsAvailable).toBeDefined();
 });
 
 test('should export method `base64URLStringToBuffer`', () => {

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -7,10 +7,14 @@ import { startAuthentication } from './methods/startAuthentication';
 import { browserSupportsWebAuthn } from './helpers/browserSupportsWebAuthn';
 import { platformAuthenticatorIsAvailable } from './helpers/platformAuthenticatorIsAvailable';
 import { browserSupportsWebAuthnAutofill } from './helpers/browserSupportsWebAuthnAutofill';
+import { base64URLStringToBuffer } from './helpers/base64URLStringToBuffer';
+import { bufferToBase64URLString } from './helpers/bufferToBase64URLString';
 
 export {
+  base64URLStringToBuffer,
   browserSupportsWebAuthn,
   browserSupportsWebAuthnAutofill,
+  bufferToBase64URLString,
   platformAuthenticatorIsAvailable,
   startAuthentication,
   startRegistration,


### PR DESCRIPTION
This simple PR makes the following complimentary helper methods available in **@simplewebauthn/browser**:

- `base64URLStringToBuffer()`
- `bufferToBase64URLString()`

Addresses #401.