### PR TITLE
fix/446-enforce-conditional-ui-autocomplete-token-order

### DIFF
--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -297,6 +297,22 @@ test('should set up autofill a.k.a. Conditional UI', async () => {
     .toEqual(0);
 });
 
+test('should set up conditional UI if "webauthn" is the only autocomplete token', async () => {
+  /**
+   * According to WHATWG "webauthn" can be the only token in the autocomplete attribute:
+   * https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens
+   */
+  document.body.innerHTML = `
+    <form>
+      <label for="username">Username</label>
+      <input type="text" name="username" autocomplete="webauthn" />
+      <button type="submit">Submit</button>
+    </form>
+  `;
+
+  await expect(startAuthentication(goodOpts1, true)).resolves;
+});
+
 test('should throw error if autofill not supported', async () => {
   mockSupportsAutofill.mockResolvedValue(false);
 
@@ -311,6 +327,25 @@ test('should throw error if no acceptable <input> is found', async () => {
     <form>
       <label for="username">Username</label>
       <input type="text" name="username" autocomplete="username" />
+      <button type="submit">Submit</button>
+    </form>
+  `;
+
+  const rejected = await expect(startAuthentication(goodOpts1, true)).rejects;
+  rejected.toThrow(Error);
+  rejected.toThrow(/no <input>/i);
+});
+
+test('should throw error if "webauthn" is not final autocomplete token', async () => {
+  /**
+   * According to WHATWG "webauthn" must be the final token in the autocomplete attribute when
+   * multiple tokens are present:
+   * https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens
+   */
+  document.body.innerHTML = `
+    <form>
+      <label for="username">Username</label>
+      <input type="text" name="username" autocomplete="webauthn username" />
       <button type="submit">Submit</button>
     </form>
   `;

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -65,7 +65,7 @@ export async function startAuthentication(
     // WebAuthn autofill requires at least one valid input
     if (eligibleInputs.length < 1) {
       throw Error(
-        'No <input> with `"webauthn"` as the only or last value in its `autocomplete` attribute was detected',
+        'No <input> with "webauthn" as the only or last value in its `autocomplete` attribute was detected',
       );
     }
 

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -59,13 +59,13 @@ export async function startAuthentication(
 
     // Check for an <input> with "webauthn" in its `autocomplete` attribute
     const eligibleInputs = document.querySelectorAll(
-      'input[autocomplete*=\'webauthn\']',
+      'input[autocomplete$=\'webauthn\']',
     );
 
     // WebAuthn autofill requires at least one valid input
     if (eligibleInputs.length < 1) {
       throw Error(
-        'No <input> with `"webauthn"` in its `autocomplete` attribute was detected',
+        'No <input> with `"webauthn"` as the only or last value in its `autocomplete` attribute was detected',
       );
     }
 


### PR DESCRIPTION
This PR tweaks `startAuthentication()` in **browser** to check that the `"webauthn"` value in an `<input>`'s `autocomplete` attribute is either the sole value or the **last** value. This [aligns things with the WHATWG](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens), which helps conditional UI appear more reliably in browsers that enforce autocomplete token order (i.e. Chrome.)

![Screenshot 2023-10-02 at 11 10 04 PM](https://github.com/MasterKale/SimpleWebAuthn/assets/5166470/965d3142-637f-4dec-a407-67f75d9265fa)

Fixes #446.