### PR TITLE
Fix `@simplewebauthn/server` not working in edge environments

### DIFF
--- a/packages/server/build_npm.ts
+++ b/packages/server/build_npm.ts
@@ -70,8 +70,9 @@ await build({
       name: '@hexagon/base64',
       version: '^1.1.27',
     },
-    'https://deno.land/x/cbor@v1.5.2/index.js': {
+    'https://deno.land/x/cbor@v1.5.2/encode.js': {
       name: 'cbor-x',
+      subPath: 'encode',
       version: '^1.5.2',
     },
     'https://esm.sh/cross-fetch@4.0.0': {

--- a/packages/server/deno.lock
+++ b/packages/server/deno.lock
@@ -98,7 +98,6 @@
     "https://deno.land/x/b64@1.1.27/src/base64.js": "9e10b98e4203d030bc913913a2e4683b4842aff337bc9ec2643a28dfe04b5fc4",
     "https://deno.land/x/cbor@v1.5.2/decode.js": "ab5518450c1cc3d8e3be7a772de8008d2a4f92626630eed6fabd66a25f565526",
     "https://deno.land/x/cbor@v1.5.2/encode.js": "80da1bb1c2936bba0b53e7e0945d73c5a55ed62ea659cf3d785514310b4e3d37",
-    "https://deno.land/x/cbor@v1.5.2/index.js": "cc8678819d77aa34b6fa9293658d85d5e53e53eaf555f85b0f98a8a18dbfaa12",
     "https://deno.land/x/cbor@v1.5.2/iterators.js": "744e0469fe37c33bab3787608ced2f2cda014cb9352b3adbd949a2701f043aea",
     "https://deno.land/x/code_block_writer@12.0.0/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",
     "https://deno.land/x/code_block_writer@12.0.0/utils/string_utils.ts": "60cb4ec8bd335bf241ef785ccec51e809d576ff8e8d29da43d2273b69ce2a6ff",

--- a/packages/server/src/deps.ts
+++ b/packages/server/src/deps.ts
@@ -18,7 +18,7 @@ export type {
 } from '../../typescript-types/src/index.ts';
 
 // cbor (a.k.a. cbor-x in Node land)
-export * as cborx from 'https://deno.land/x/cbor@v1.5.2/index.js';
+export * as cborx from 'https://deno.land/x/cbor@v1.5.2/encode.js';
 
 // b64 (a.k.a. @hexagon/base64 in Node land)
 export { default as base64 } from 'https://deno.land/x/b64@1.1.27/src/base64.js';


### PR DESCRIPTION
One of @simplewebauthn/server dependencies cbor-x, [supports streams](https://github.com/kriszyp/cbor-x#streams), which uses Node's and Deno's [`stream`](https://nodejs.org/api/stream.html) interface.

Unfortunately, `stream` is not part of the standard Web APIs that many edge compute runtimes use (e.g. Vercel [doesn't support it](https://nextjs.org/docs/pages/api-reference/edge), and Cloudflare requires a [separate `node:`](https://blog.cloudflare.com/workers-node-js-apis-stream-path/#stream) namespace). Importing it throws errors like these:
![Screenshot 2023-10-06 at 13 09 30](https://github.com/MasterKale/SimpleWebAuthn/assets/19658460/e48d8223-88e4-42a5-9138-e0b14bbe9cb0)


Since the only object used from cbor-x is `Encoder`, the fix is pretty simple. Instead of importing the entire  package, we only import its encode file, which is officially exported. This avoids loading the `stream.js` file that uses `stream`.

I tested it by patching @simplewebauthn/server directly in my node_modules and it worked without issues, but I haven't attempted to build it locally. I don't see a reason for it not building, though.