### PR TITLE
fix/463-restore-authdata-after-bad-cbor-fix

### DIFF
--- a/packages/server/src/helpers/parseAuthenticatorData.test.ts
+++ b/packages/server/src/helpers/parseAuthenticatorData.test.ts
@@ -74,11 +74,17 @@ Deno.test('should parse malformed authenticator data from Firefox 117', () => {
    * - https://github.com/duo-labs/py_webauthn/issues/175
    * - https://github.com/mozilla/authenticator-rs/pull/292
    */
-  const authDataBadKty =
+  const authDataBadKtyHex =
     'b40499b0271a68957267de4ec40056a74c8758c6582e1e01fcf357d73101e7ba450000000400000000000000000000000000000000008072d3a1a3fa7cf32f44367df847585ff0850c7bd62c338ab45be1fda6fdb79982f96c20efc0bb6ed9347e8c1e77690e67b225b485a098f6f46fde3f2a85acd0177a04d6bb5c7566fb89881dfe48ea7abc361f7acaf86a5966adef557930fa5c045c636f50cf938e508a81b845134eb2988dc3af0ab6f98cfc615532684b4a6363a301634f4b50032720674564323535313921982018d51858187318e6188918eb18ab187e18fd18fd185d184b08184b187318e818e118f818c71518ff18f5183a18fd18a3186b185f1109183e183b14';
+  const authData = isoUint8Array.fromHex(authDataBadKtyHex);
 
-  const parsed = parseAuthenticatorData(isoUint8Array.fromHex(authDataBadKty));
+  const parsed = parseAuthenticatorData(authData);
+
+  const authDataAfterHex = isoUint8Array.toHex(authData);
 
   // If we can assert this then it means we could parse the bad auth data above
   assertEquals(parsed.flags.at, true);
+  // Let's make sure we didn't fundamentally change authData as it would break signature
+  // verification if we did.
+  assertEquals(authDataBadKtyHex, authDataAfterHex);
 });


### PR DESCRIPTION
This PR restores the bit that gets flipped when we detect bad CBOR encoding from Firefox (see #441) so that `authData` isn't permanently changed and signature verification has a chance to succeed (since `authData` is part of the info that get signed over during registration.)

Fixes an issue discovered while looking at #463. 