### PR TITLE
fix/460-track-browser-dom-ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ example/*.crt
 example/fido-conformance-mds/*
 !example/fido-conformance-mds/.gitkeep
 packages/*/package-lock.json
-packages/typescript-types/src/dom.ts
 scratchenv/

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -4,6 +4,16 @@ Notes for myself that I don't want cluttering up the README
 
 ## Deployment Process
 
+### Step 0: Things you might have missed
+
+#### Did you update the version of `"typescript"` in the monorepo's root **package.json** file?
+
+Run this first to update **packages/typescript-types/dom.ts** then commit the changes:
+
+```
+(cd packages/typescript-types; pnpm run extract-dom-types)
+```
+
 ### Step 1: Determine which packages need to be published
 
 ```

--- a/packages/typescript-types/extract-dom-types.ts
+++ b/packages/typescript-types/extract-dom-types.ts
@@ -87,9 +87,12 @@ const outputSourceFile = project.createSourceFile(`src/dom.ts`, undefined, {
   overwrite: true,
 });
 outputSourceFile.addStatements([
-  `// Generated from typescript@${version} ${domSourcePath}`,
-  `// To regenerate, run the following command from the project root:`,
-  `// npx lerna --scope=@simplewebauthn/typescript-types exec -- npm run extract-dom-types`,
+  `/**`,
+  ` * Generated from typescript@${version} ${domSourcePath}`,
+  ` * To regenerate, run the following command from the project root:`,
+  ` * npx lerna --scope=@simplewebauthn/typescript-types exec -- npm run extract-dom-types`,
+  ` */`,
+  `// BEGIN CODEGEN`,
 ]);
 const resolvedStructures = Array.from(resolvedNodes).map((node) => node.getStructure());
 outputSourceFile.addInterfaces(

--- a/packages/typescript-types/package.json
+++ b/packages/typescript-types/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "description": "Lerna/npm wrapper around Deno for @simplewebauthn/typescript-types",
   "scripts": {
-    "build": "npm run extract-dom-types && deno task build",
+    "build": "deno task build",
     "extract-dom-types": "ts-node extract-dom-types.ts"
   },
   "lerna": {

--- a/packages/typescript-types/src/dom.ts
+++ b/packages/typescript-types/src/dom.ts
@@ -1,0 +1,357 @@
+/**
+ * Generated from typescript@5.1.6 typescript/lib/lib.dom.d.ts
+ * To regenerate, run the following command from the project root:
+ * npx lerna --scope=@simplewebauthn/typescript-types exec -- npm run extract-dom-types
+ */
+// BEGIN CODEGEN
+/**
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse)
+ */
+export interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/authenticatorData) */
+    readonly authenticatorData: ArrayBuffer;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/signature) */
+    readonly signature: ArrayBuffer;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/userHandle) */
+    readonly userHandle: ArrayBuffer | null;
+}
+
+/**
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse)
+ */
+export interface AuthenticatorAttestationResponse extends AuthenticatorResponse {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/attestationObject) */
+    readonly attestationObject: ArrayBuffer;
+    getAuthenticatorData(): ArrayBuffer;
+    getPublicKey(): ArrayBuffer | null;
+    getPublicKeyAlgorithm(): COSEAlgorithmIdentifier;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports) */
+    getTransports(): string[];
+}
+
+export interface AuthenticationExtensionsClientInputs {
+    appid?: string;
+    credProps?: boolean;
+    hmacCreateSecret?: boolean;
+}
+
+export interface AuthenticationExtensionsClientOutputs {
+    appid?: boolean;
+    credProps?: CredentialPropertiesOutput;
+    hmacCreateSecret?: boolean;
+}
+
+export interface AuthenticatorSelectionCriteria {
+    authenticatorAttachment?: AuthenticatorAttachment;
+    requireResidentKey?: boolean;
+    residentKey?: ResidentKeyRequirement;
+    userVerification?: UserVerificationRequirement;
+}
+
+/**
+ * Basic cryptography features available in the current context. It allows access to a cryptographically strong random number generator and to cryptographic primitives.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto)
+ */
+export interface Crypto {
+    /**
+     * Available only in secure contexts.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/subtle)
+     */
+    readonly subtle: SubtleCrypto;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/getRandomValues) */
+    getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+    /**
+     * Available only in secure contexts.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
+     */
+    randomUUID(): `${string}-${string}-${string}-${string}-${string}`;
+}
+
+/**
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential)
+ */
+export interface PublicKeyCredential extends Credential {
+    readonly authenticatorAttachment: string | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/rawId) */
+    readonly rawId: ArrayBuffer;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/response) */
+    readonly response: AuthenticatorResponse;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults) */
+    getClientExtensionResults(): AuthenticationExtensionsClientOutputs;
+}
+
+export interface PublicKeyCredentialCreationOptions {
+    attestation?: AttestationConveyancePreference;
+    authenticatorSelection?: AuthenticatorSelectionCriteria;
+    challenge: BufferSource;
+    excludeCredentials?: PublicKeyCredentialDescriptor[];
+    extensions?: AuthenticationExtensionsClientInputs;
+    pubKeyCredParams: PublicKeyCredentialParameters[];
+    rp: PublicKeyCredentialRpEntity;
+    timeout?: number;
+    user: PublicKeyCredentialUserEntity;
+}
+
+export interface PublicKeyCredentialDescriptor {
+    id: BufferSource;
+    transports?: AuthenticatorTransport[];
+    type: PublicKeyCredentialType;
+}
+
+export interface PublicKeyCredentialParameters {
+    alg: COSEAlgorithmIdentifier;
+    type: PublicKeyCredentialType;
+}
+
+export interface PublicKeyCredentialRequestOptions {
+    allowCredentials?: PublicKeyCredentialDescriptor[];
+    challenge: BufferSource;
+    extensions?: AuthenticationExtensionsClientInputs;
+    rpId?: string;
+    timeout?: number;
+    userVerification?: UserVerificationRequirement;
+}
+
+export interface PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity {
+    displayName: string;
+    id: BufferSource;
+}
+
+/**
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse)
+ */
+export interface AuthenticatorResponse {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse/clientDataJSON) */
+    readonly clientDataJSON: ArrayBuffer;
+}
+
+export interface CredentialPropertiesOutput {
+    rk?: boolean;
+}
+
+/**
+ * This Web Crypto API interface provides a number of low-level cryptographic functions. It is accessed via the Crypto.subtle properties available in a window context (via Window.crypto).
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto)
+ */
+export interface SubtleCrypto {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt) */
+    decrypt(algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, key: CryptoKey, data: BufferSource): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits) */
+    deriveBits(algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length: number): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey) */
+    deriveKey(algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AlgorithmIdentifier | AesDerivedKeyParams | HmacImportParams | HkdfParams | Pbkdf2Params, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest) */
+    digest(algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt) */
+    encrypt(algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, key: CryptoKey, data: BufferSource): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey) */
+    exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
+    exportKey(format: Exclude<KeyFormat, "jwk">, key: CryptoKey): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey) */
+    generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKeyPair>;
+    generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
+    generateKey(algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKeyPair | CryptoKey>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey) */
+    importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
+    importKey(format: Exclude<KeyFormat, "jwk">, keyData: BufferSource, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) */
+    sign(algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams, key: CryptoKey, data: BufferSource): Promise<ArrayBuffer>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey) */
+    unwrapKey(format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, unwrappedKeyAlgorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) */
+    verify(algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams, key: CryptoKey, signature: BufferSource, data: BufferSource): Promise<boolean>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey) */
+    wrapKey(format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams): Promise<ArrayBuffer>;
+}
+
+/**
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Credential)
+ */
+export interface Credential {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Credential/id) */
+    readonly id: string;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Credential/type) */
+    readonly type: string;
+}
+
+export interface PublicKeyCredentialRpEntity extends PublicKeyCredentialEntity {
+    id?: string;
+}
+
+export interface PublicKeyCredentialEntity {
+    name: string;
+}
+
+export interface RsaOaepParams extends Algorithm {
+    label?: BufferSource;
+}
+
+export interface AesCtrParams extends Algorithm {
+    counter: BufferSource;
+    length: number;
+}
+
+export interface AesCbcParams extends Algorithm {
+    iv: BufferSource;
+}
+
+export interface AesGcmParams extends Algorithm {
+    additionalData?: BufferSource;
+    iv: BufferSource;
+    tagLength?: number;
+}
+
+/**
+ * The CryptoKey dictionary of the Web Crypto API represents a cryptographic key.
+ * Available only in secure contexts.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey)
+ */
+export interface CryptoKey {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/algorithm) */
+    readonly algorithm: KeyAlgorithm;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/extractable) */
+    readonly extractable: boolean;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/type) */
+    readonly type: KeyType;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/usages) */
+    readonly usages: KeyUsage[];
+}
+
+export interface EcdhKeyDeriveParams extends Algorithm {
+    public: CryptoKey;
+}
+
+export interface HkdfParams extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+    info: BufferSource;
+    salt: BufferSource;
+}
+
+export interface Pbkdf2Params extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+    iterations: number;
+    salt: BufferSource;
+}
+
+export interface AesDerivedKeyParams extends Algorithm {
+    length: number;
+}
+
+export interface HmacImportParams extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+    length?: number;
+}
+
+export interface JsonWebKey {
+    alg?: string;
+    crv?: string;
+    d?: string;
+    dp?: string;
+    dq?: string;
+    e?: string;
+    ext?: boolean;
+    k?: string;
+    key_ops?: string[];
+    kty?: string;
+    n?: string;
+    oth?: RsaOtherPrimesInfo[];
+    p?: string;
+    q?: string;
+    qi?: string;
+    use?: string;
+    x?: string;
+    y?: string;
+}
+
+export interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+    hash: HashAlgorithmIdentifier;
+}
+
+export interface EcKeyGenParams extends Algorithm {
+    namedCurve: NamedCurve;
+}
+
+export interface CryptoKeyPair {
+    privateKey: CryptoKey;
+    publicKey: CryptoKey;
+}
+
+export interface AesKeyGenParams extends Algorithm {
+    length: number;
+}
+
+export interface HmacKeyGenParams extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+    length?: number;
+}
+
+export interface RsaHashedImportParams extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+}
+
+export interface EcKeyImportParams extends Algorithm {
+    namedCurve: NamedCurve;
+}
+
+export interface AesKeyAlgorithm extends KeyAlgorithm {
+    length: number;
+}
+
+export interface RsaPssParams extends Algorithm {
+    saltLength: number;
+}
+
+export interface EcdsaParams extends Algorithm {
+    hash: HashAlgorithmIdentifier;
+}
+
+export interface Algorithm {
+    name: string;
+}
+
+export interface KeyAlgorithm {
+    name: string;
+}
+
+export interface RsaOtherPrimesInfo {
+    d?: string;
+    r?: string;
+    t?: string;
+}
+
+export interface RsaKeyGenParams extends Algorithm {
+    modulusLength: number;
+    publicExponent: BigInteger;
+}
+
+export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
+export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
+export type COSEAlgorithmIdentifier = number;
+export type UserVerificationRequirement = "discouraged" | "preferred" | "required";
+export type AuthenticatorAttachment = "cross-platform" | "platform";
+export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
+export type BufferSource = ArrayBufferView | ArrayBuffer;
+export type PublicKeyCredentialType = "public-key";
+export type AlgorithmIdentifier = Algorithm | string;
+export type KeyUsage = "decrypt" | "deriveBits" | "deriveKey" | "encrypt" | "sign" | "unwrapKey" | "verify" | "wrapKey";
+export type KeyFormat = "jwk" | "pkcs8" | "raw" | "spki";
+export type KeyType = "private" | "public" | "secret";
+export type HashAlgorithmIdentifier = AlgorithmIdentifier;
+export type NamedCurve = string;
+export type BigInteger = Uint8Array;


### PR DESCRIPTION
This PR starts tracking **packages/typescript-types/dom.ts** so that the import from `"./dom.ts"` in **index.ts** can resolve in Deno projects.

And this file doesn't often need to be codegen'd, only when I update the version of TypeScript specified in the root **package.json**, so I won't codegen **dom.ts** on builds anymore.

To confirm the fix I ran the following and confirmed the `deno vendor` command succeeded:

```sh
$> cd scratchenv/460-deno-types-dom-ts
$> deno vendor ../../deno/server.ts --no-config --force
Vendored 101 modules into vendor/ directory.

To use vendored modules, specify the `--import-map vendor/import_map.json` flag when invoking Deno subcommands or add an `"importMap": "<path_to_vendored_import_map>"` entry to a deno.json file.
```

Fixes #460.