### PR TITLE
fix/better-get-web-crypto

### DIFF
--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from 'https://deno.land/std@0.198.0/assert/mod.ts';
+import { returnsNext, stub } from 'https://deno.land/std@0.198.0/testing/mock.ts';
+
+import { _getWebCryptoInternals, getWebCrypto } from './getWebCrypto.ts';
+
+Deno.test('Should return globalThis.crypto when present', async () => {
+  // Back up globalThis.crypto
+  const originalCrypto = globalThis.crypto;
+
+  // Overwrite globalThis.crypto
+  const newCrypto = {};
+  Object.defineProperty(globalThis, 'crypto', { value: newCrypto, writable: true });
+
+  const returnedCrypto = await getWebCrypto();
+
+  assertEquals(returnedCrypto, newCrypto);
+
+  // Restore globalThis.crypto
+  Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, writable: true });
+});
+
+Deno.test('Should return node:crypto.webcrypto when globalThis.crypto is missing', async () => {
+  // Mock out just enough of the 'node:crypto' module
+  const fakeNodeCrypto = { webcrypto: {} };
+  const mockDecodeClientData = stub(
+    _getWebCryptoInternals,
+    'stubThisImportNodeCrypto',
+    // @ts-ignore: Pretending to return something from Node
+    returnsNext([fakeNodeCrypto]),
+  );
+
+  // Back up globalThis.crypto
+  const originalCrypto = globalThis.crypto;
+
+  // Overwrite globalThis.crypto
+  const newCrypto = undefined;
+  Object.defineProperty(globalThis, 'crypto', { value: newCrypto, writable: true });
+
+  const returnedCrypto = await getWebCrypto();
+
+  assertEquals(returnedCrypto, fakeNodeCrypto.webcrypto);
+
+  // Restore globalThis.crypto
+  Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, writable: true });
+  mockDecodeClientData.restore();
+});
+
+Deno.test(
+  'Should return globalThis.crypto when present, while node:crypto is present but missing webcrypto',
+  async () => {
+    // Mock out just enough of the 'node:crypto' module, but like we're in Node v14
+    const fakeNodeCrypto = { webcrypto: undefined };
+    const mockDecodeClientData = stub(
+      _getWebCryptoInternals,
+      'stubThisImportNodeCrypto',
+      // @ts-ignore: Pretending to return something from Node
+      returnsNext([fakeNodeCrypto]),
+    );
+
+    // Back up globalThis.crypto
+    const originalCrypto = globalThis.crypto;
+
+    // Overwrite globalThis.crypto
+    const fakeGlobalCrypto = {};
+    Object.defineProperty(globalThis, 'crypto', { value: fakeGlobalCrypto, writable: true });
+
+    const returnedCrypto = await getWebCrypto();
+
+    assertEquals(returnedCrypto, fakeGlobalCrypto);
+
+    // Restore globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, writable: true });
+    mockDecodeClientData.restore();
+  },
+);

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
@@ -4,6 +4,9 @@ import { returnsNext, stub } from 'https://deno.land/std@0.198.0/testing/mock.ts
 import { _getWebCryptoInternals, getWebCrypto, MissingWebCrypto } from './getWebCrypto.ts';
 
 Deno.test('should return globalThis.crypto when present', async () => {
+  // Clear whatever version of crypto might have been set
+  _getWebCryptoInternals.setCachedCrypto(undefined);
+
   // Pretend globalThis.crypto exists
   const newGlobalThisCrypto = {};
   const mockGlobalThisCrypto = stub(
@@ -21,6 +24,9 @@ Deno.test('should return globalThis.crypto when present', async () => {
 });
 
 Deno.test('should return node:crypto.webcrypto when globalThis.crypto is missing', async () => {
+  // Clear whatever version of crypto might have been set
+  _getWebCryptoInternals.setCachedCrypto(undefined);
+
   // Pretend globalThis.crypto doesn't exist
   const mockGlobalThisCrypto = stub(
     _getWebCryptoInternals,
@@ -49,6 +55,9 @@ Deno.test('should return node:crypto.webcrypto when globalThis.crypto is missing
 Deno.test(
   'should return globalThis.crypto when present, while node:crypto.webcrypto is present',
   async () => {
+    // Clear whatever version of crypto might have been set
+    _getWebCryptoInternals.setCachedCrypto(undefined);
+
     // Pretend globalThis.crypto exists
     const fakeGlobalThisCrypto = {};
     const mockGlobalThisCrypto = stub(
@@ -79,6 +88,9 @@ Deno.test(
 Deno.test(
   'should return globalThis.crypto when present, while node:crypto is present but missing webcrypto',
   async () => {
+    // Clear whatever version of crypto might have been set
+    _getWebCryptoInternals.setCachedCrypto(undefined);
+
     // Pretend globalThis.crypto exists
     const fakeGlobalThisCrypto = {};
     const mockGlobalThisCrypto = stub(

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
@@ -29,7 +29,6 @@ export async function getWebCrypto(): Promise<Crypto> {
     const _crypto = await _getWebCryptoInternals.stubThisImportNodeCrypto();
 
     if (_crypto.webcrypto) {
-      console.log('node:crypto.webcrypto');
       webCrypto = _crypto.webcrypto as Crypto;
       return webCrypto;
     }

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
@@ -15,7 +15,7 @@ export async function getWebCrypto(): Promise<Crypto> {
    * Naively attempt to access Crypto as a global object, which popular alternative run-times
    * support.
    */
-  const _crypto = globalThis.crypto;
+  const _crypto = _getWebCryptoInternals.stubThisGlobalThisCrypto();
 
   if (_crypto) {
     webCrypto = _crypto;
@@ -40,7 +40,7 @@ export async function getWebCrypto(): Promise<Crypto> {
   throw new MissingWebCrypto();
 }
 
-class MissingWebCrypto extends Error {
+export class MissingWebCrypto extends Error {
   constructor() {
     const message = 'An instance of the Crypto API could not be located';
     super(message);
@@ -52,4 +52,9 @@ class MissingWebCrypto extends Error {
 export const _getWebCryptoInternals = {
   // dnt-shim-ignore
   stubThisImportNodeCrypto: () => import('node:crypto'),
+  stubThisGlobalThisCrypto: () => globalThis.crypto,
+  // Make it possible to reset the `webCrypto` at the top of the file
+  setCachedCrypto: (newCrypto: Crypto | undefined) => {
+    webCrypto = newCrypto;
+  },
 };

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
@@ -11,31 +11,34 @@ export async function getWebCrypto(): Promise<Crypto> {
     return webCrypto;
   }
 
-  try {
-    /**
-     * Naively attempt a Node import...
-     */
-    // @ts-ignore: We'll handle any errors...
-    // dnt-shim-ignore
-    const _crypto = await import('node:crypto');
-    webCrypto = _crypto.webcrypto as Crypto;
-  } catch (_err) {
-    /**
-     * Naively attempt to access Crypto as a global object, which popular alternative run-times
-     * support.
-     */
-    // @ts-ignore: ...right here.
-    const _crypto: Crypto = globalThis.crypto;
+  /**
+   * Naively attempt to access Crypto as a global object, which popular alternative run-times
+   * support.
+   */
+  const _crypto = globalThis.crypto;
 
-    if (!_crypto) {
-      // We tried to access it both in Node and globally, so bail out
-      throw new MissingWebCrypto();
-    }
-
+  if (_crypto) {
     webCrypto = _crypto;
+    return webCrypto;
   }
 
-  return webCrypto;
+  try {
+    /**
+     * `globalThis.crypto` isn't available, so attempt a Node import...
+     */
+    const _crypto = await _getWebCryptoInternals.stubThisImportNodeCrypto();
+
+    if (_crypto.webcrypto) {
+      console.log('node:crypto.webcrypto');
+      webCrypto = _crypto.webcrypto as Crypto;
+      return webCrypto;
+    }
+  } catch (_err) {
+    // pass
+  }
+
+  // We tried to access it both in Node and globally, so bail out
+  throw new MissingWebCrypto();
 }
 
 class MissingWebCrypto extends Error {
@@ -45,3 +48,9 @@ class MissingWebCrypto extends Error {
     this.name = 'MissingWebCrypto';
   }
 }
+
+// Make it possible to stub return values during testing
+export const _getWebCryptoInternals = {
+  // dnt-shim-ignore
+  stubThisImportNodeCrypto: () => import('node:crypto'),
+};


### PR DESCRIPTION
This PR refines the logic inside **server**'s `getWebCrypto()` to support more runtime environments. In particular it should now support CloudFlare Workers with Node polyfills enabled but still missing `import('node:crypto').webcrypto` (this is similar to Node v14 environments, but the CF docs don't explicitly state a target Node version and say they _do_ support `webcrypto` in https://developers.cloudflare.com/workers/runtime-apis/nodejs/crypto/#webcrypto 🤷‍♂️)

Supercedes #457 (this PR also adds test coverage over this trickier method to write tests for.)