### PR TITLE
fix/471-more-resilient-getwebcrypto

### DIFF
--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
@@ -41,7 +41,7 @@ Deno.test('should return node:crypto.webcrypto when globalThis.crypto is missing
     _getWebCryptoInternals,
     'stubThisImportNodeCrypto',
     // @ts-ignore: node:crypto
-    returnsNext([fakeNodeCrypto]),
+    returnsNext([Promise.resolve(fakeNodeCrypto)]),
   );
 
   const returnedCrypto = await getWebCrypto();
@@ -73,7 +73,7 @@ Deno.test(
       _getWebCryptoInternals,
       'stubThisImportNodeCrypto',
       // @ts-ignore: node:crypto
-      returnsNext([fakeNodeCrypto]),
+      returnsNext([Promise.resolve(fakeNodeCrypto)]),
     );
 
     const returnedCrypto = await getWebCrypto();
@@ -106,7 +106,7 @@ Deno.test(
       _getWebCryptoInternals,
       'stubThisImportNodeCrypto',
       // @ts-ignore: node:crypto
-      returnsNext([fakeNodeCrypto]),
+      returnsNext([Promise.resolve(fakeNodeCrypto)]),
     );
 
     const returnedCrypto = await getWebCrypto();
@@ -135,7 +135,7 @@ Deno.test('should raise MissingWebCrypto error when nothing is available', async
     _getWebCryptoInternals,
     'stubThisImportNodeCrypto',
     // @ts-ignore: node:crypto
-    returnsNext([undefined]),
+    returnsNext([Promise.resolve({ webcrypto: undefined })]),
   );
 
   await assertRejects(

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
@@ -15,25 +15,23 @@ export async function getWebCrypto(): Promise<Crypto> {
    * Naively attempt to access Crypto as a global object, which popular alternative run-times
    * support.
    */
-  const _crypto = _getWebCryptoInternals.stubThisGlobalThisCrypto();
+  const _globalThisCrypto = _getWebCryptoInternals.stubThisGlobalThisCrypto();
 
-  if (_crypto) {
-    webCrypto = _crypto;
+  if (_globalThisCrypto) {
+    console.log('globalThis.crypto');
+    webCrypto = _globalThisCrypto;
     return webCrypto;
   }
 
-  try {
-    /**
-     * `globalThis.crypto` isn't available, so attempt a Node import...
-     */
-    const _crypto = await _getWebCryptoInternals.stubThisImportNodeCrypto();
+  /**
+   * `globalThis.crypto` isn't available, so attempt a Node import...
+   */
+  const _nodeCrypto = await _getWebCryptoInternals.stubThisImportNodeCrypto();
 
-    if (_crypto.webcrypto) {
-      webCrypto = _crypto.webcrypto as Crypto;
-      return webCrypto;
-    }
-  } catch (_err) {
-    // pass
+  if (_nodeCrypto?.webcrypto) {
+    console.log('node:crypto');
+    webCrypto = _nodeCrypto.webcrypto as Crypto;
+    return webCrypto;
   }
 
   // We tried to access it both in Node and globally, so bail out
@@ -50,8 +48,21 @@ export class MissingWebCrypto extends Error {
 
 // Make it possible to stub return values during testing
 export const _getWebCryptoInternals = {
-  // dnt-shim-ignore
-  stubThisImportNodeCrypto: () => import('node:crypto'),
+  stubThisImportNodeCrypto: async () => {
+    try {
+      // dnt-shim-ignore
+      const _nodeCrypto = await import('node:crypto');
+      return _nodeCrypto;
+    } catch (_err) {
+      /**
+       * Intentionally declaring webcrypto as undefined because we're assuming the Node import
+       * failed due to either:
+       * - `import()` isn't supported
+       * - `node:crypto` is unavailable.
+       */
+      return { webcrypto: undefined };
+    }
+  },
   stubThisGlobalThisCrypto: () => globalThis.crypto,
   // Make it possible to reset the `webCrypto` at the top of the file
   setCachedCrypto: (newCrypto: Crypto | undefined) => {

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.ts
@@ -18,7 +18,6 @@ export async function getWebCrypto(): Promise<Crypto> {
   const _globalThisCrypto = _getWebCryptoInternals.stubThisGlobalThisCrypto();
 
   if (_globalThisCrypto) {
-    console.log('globalThis.crypto');
     webCrypto = _globalThisCrypto;
     return webCrypto;
   }
@@ -29,7 +28,6 @@ export async function getWebCrypto(): Promise<Crypto> {
   const _nodeCrypto = await _getWebCryptoInternals.stubThisImportNodeCrypto();
 
   if (_nodeCrypto?.webcrypto) {
-    console.log('node:crypto');
     webCrypto = _nodeCrypto.webcrypto as Crypto;
     return webCrypto;
   }


### PR DESCRIPTION
This PR refines the changes made to `getWebCrypto()` in #468 by moving the `try / catch` into `_getWebCryptoInternals.stubThisImportNodeCrypto`. This should prevent non-Node runtimes from A) getting hung up on the use of `import()` or B) trying to use it to import a Node-specific identifier.

In an effort to confirm the fix, I tested these changes in the following "edge runtimes":

- A simple [Astro project](https://docs.astro.build/en/install/auto/), and also with `npx astro add cloudflare` added in for CF support (as per #471)
  - `npm start` wouldn't recreate the original issue, but I confirmed that `npm run build` experienced the error described in #471 with **@simplewebauthn/server@8.3.4** but not with these changes
- A [basic CloudFlare Worker](https://developers.cloudflare.com/workers/get-started/guide/) project, and again with `compatibility_flags = [ "nodejs_compat" ]` in **wrangler.toml**

I tested with the following code:

```ts
import { generateAuthenticationOptions } from '@simplewebauthn/server';

// ...

const opts = await generateAuthenticationOptions(); 
```

## Proof

### Astro

![Screenshot 2023-10-27 at 8 48 10 PM](https://github.com/MasterKale/SimpleWebAuthn/assets/5166470/3cab5187-5998-4895-a40e-48139fd695a4)

### CloudFlare Worker

![Screenshot 2023-10-27 at 8 42 20 PM](https://github.com/MasterKale/SimpleWebAuthn/assets/5166470/1368d3d3-83a8-45fc-9731-e8acaa469390)