### PR TITLE
fix/477-make-uv-optional-in-example

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -227,7 +227,7 @@ app.get('/generate-authentication-options', async (req, res) => {
       type: 'public-key',
       transports: dev.transports,
     })),
-    userVerification: 'required',
+    userVerification: 'preferred',
     rpID,
   };
 
@@ -273,7 +273,7 @@ app.post('/verify-authentication', async (req, res) => {
       expectedOrigin,
       expectedRPID: rpID,
       authenticator: dbAuthenticator,
-      requireUserVerification: true,
+      requireUserVerification: false,
     };
     verification = await verifyAuthenticationResponse(opts);
   } catch (error) {

--- a/example/index.ts
+++ b/example/index.ts
@@ -143,6 +143,11 @@ app.get('/generate-registration-options', async (req, res) => {
     })),
     authenticatorSelection: {
       residentKey: 'discouraged',
+      /**
+       * Wondering why user verification isn't required here? See here:
+       *
+       * https://passkeys.dev/docs/use-cases/bootstrapping/#a-note-about-user-verification
+       */
       userVerification: 'preferred',
     },
     /**
@@ -227,6 +232,11 @@ app.get('/generate-authentication-options', async (req, res) => {
       type: 'public-key',
       transports: dev.transports,
     })),
+    /**
+     * Wondering why user verification isn't required here? See here:
+     *
+     * https://passkeys.dev/docs/use-cases/bootstrapping/#a-note-about-user-verification
+     */
     userVerification: 'preferred',
     rpID,
   };

--- a/example/index.ts
+++ b/example/index.ts
@@ -143,6 +143,7 @@ app.get('/generate-registration-options', async (req, res) => {
     })),
     authenticatorSelection: {
       residentKey: 'discouraged',
+      userVerification: 'preferred',
     },
     /**
      * Support the two most common algorithms: ES256, and RS256
@@ -175,7 +176,7 @@ app.post('/verify-registration', async (req, res) => {
       expectedChallenge: `${expectedChallenge}`,
       expectedOrigin,
       expectedRPID: rpID,
-      requireUserVerification: true,
+      requireUserVerification: false,
     };
     verification = await verifyRegistrationResponse(opts);
   } catch (error) {

--- a/example/index.ts
+++ b/example/index.ts
@@ -144,7 +144,7 @@ app.get('/generate-registration-options', async (req, res) => {
     authenticatorSelection: {
       residentKey: 'discouraged',
       /**
-       * Wondering why user verification isn't required here? See here:
+       * Wondering why user verification isn't required? See here:
        *
        * https://passkeys.dev/docs/use-cases/bootstrapping/#a-note-about-user-verification
        */
@@ -233,7 +233,7 @@ app.get('/generate-authentication-options', async (req, res) => {
       transports: dev.transports,
     })),
     /**
-     * Wondering why user verification isn't required here? See here:
+     * Wondering why user verification isn't required? See here:
      *
      * https://passkeys.dev/docs/use-cases/bootstrapping/#a-note-about-user-verification
      */


### PR DESCRIPTION
This PR makes UV optional in the example by preferring UV in registration and authentication options, and not requiring it when verifying responses.

Fixes #477.
