### PR TITLE
Export algorithm-specific `COSEPublicKey` types in the server package

### DIFF
--- a/packages/server/src/helpers/index.ts
+++ b/packages/server/src/helpers/index.ts
@@ -42,7 +42,7 @@ import type {
 } from './decodeAttestationObject.ts';
 import type { CertificateInfo } from './getCertificateInfo.ts';
 import type { ClientDataJSON } from './decodeClientDataJSON.ts';
-import type { COSEPublicKey } from './cose.ts';
+import type { COSEPublicKey, COSEPublicKeyEC2, COSEPublicKeyOKP, COSEPublicKeyRSA } from './cose.ts';
 import type { ParsedAuthenticatorData } from './parseAuthenticatorData.ts';
 
 export type {
@@ -52,5 +52,8 @@ export type {
   CertificateInfo,
   ClientDataJSON,
   COSEPublicKey,
+  COSEPublicKeyEC2,
+  COSEPublicKeyOKP,
+  COSEPublicKeyRSA,
   ParsedAuthenticatorData,
 };


### PR DESCRIPTION
The `decodeCredentialPublicKey` function signature returns a generic `COSEPublicKey` type, missing algorithm-specific properties. Exporting additional types would enable type casting to a specific public key type.

Perhaps it'd be handy to re-export the existing type guards, but I think plain types are enough because the developers should know which algorithm they used.