### PR TITLE
Export WebAuthnError

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -10,6 +10,7 @@ import { browserSupportsWebAuthnAutofill } from './helpers/browserSupportsWebAut
 import { base64URLStringToBuffer } from './helpers/base64URLStringToBuffer';
 import { bufferToBase64URLString } from './helpers/bufferToBase64URLString';
 import { WebAuthnAbortService } from './helpers/webAuthnAbortService';
+import { WebAuthnError } from './helpers/webAuthnError';
 
 export {
   base64URLStringToBuffer,
@@ -20,6 +21,7 @@ export {
   startAuthentication,
   startRegistration,
   WebAuthnAbortService,
+  WebAuthnError,
 };
 
 export type { WebAuthnErrorCode } from './helpers/webAuthnError';


### PR DESCRIPTION
Hi 👋

First, thanks a lot for this library, it's a life-saviour when using WebAuthn.
I have a small question, are you against exporting `WebAuthnError`? This way, we could be able to perform `instanceof` checks instead of duck typing:

```tsx
// usage example with ts-pattern:
startAuthentication({ … }).catch(error => {
  if (error instanceof WebAuthnError) {
    match(error.code) // typesafe here
      .with("ERROR_AUTHENTICATOR_GENERAL_ERROR", () => { … })
      .with("ERROR_AUTHENTICATOR_MISSING_DISCOVERABLE_CREDENTIAL_SUPPORT", () => { … })
      .with("ERROR_AUTHENTICATOR_MISSING_USER_VERIFICATION_SUPPORT", () => { … })
      .with("ERROR_AUTHENTICATOR_NO_SUPPORTED_PUBKEYCREDPARAMS_ALG", () => { … })
      .with("ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED", () => { … })
      .with("ERROR_CEREMONY_ABORTED", () => { … })
      .with("ERROR_INVALID_DOMAIN", () => { … })
      .with("ERROR_INVALID_RP_ID", () => { … })
      .with("ERROR_INVALID_USER_ID_LENGTH", () => { … })
      .with("ERROR_MALFORMED_PUBKEYCREDPARAMS", () => { … })
      .with("ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY", () => { … })
      .exhaustive();
  }
});
```

If you are against it, feel free to close this PR.