### PR TITLE
Fix edge compute issues with cbor-x dynamic functions

### DIFF
--- a/packages/server/build_npm.ts
+++ b/packages/server/build_npm.ts
@@ -70,9 +70,9 @@ await build({
       name: '@hexagon/base64',
       version: '^1.1.27',
     },
-    'https://deno.land/x/cbor@v1.5.2/encode.js': {
+    'https://deno.land/x/cbor@v1.5.2/index.js': {
       name: 'cbor-x',
-      subPath: 'encode',
+      subPath: 'index-no-eval',
       version: '^1.5.2',
     },
     'https://esm.sh/cross-fetch@4.0.0': {

--- a/packages/server/deno.lock
+++ b/packages/server/deno.lock
@@ -98,6 +98,7 @@
     "https://deno.land/x/b64@1.1.27/src/base64.js": "9e10b98e4203d030bc913913a2e4683b4842aff337bc9ec2643a28dfe04b5fc4",
     "https://deno.land/x/cbor@v1.5.2/decode.js": "ab5518450c1cc3d8e3be7a772de8008d2a4f92626630eed6fabd66a25f565526",
     "https://deno.land/x/cbor@v1.5.2/encode.js": "80da1bb1c2936bba0b53e7e0945d73c5a55ed62ea659cf3d785514310b4e3d37",
+    "https://deno.land/x/cbor@v1.5.2/index.js": "cc8678819d77aa34b6fa9293658d85d5e53e53eaf555f85b0f98a8a18dbfaa12",
     "https://deno.land/x/code_block_writer@12.0.0/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",
     "https://deno.land/x/code_block_writer@12.0.0/utils/string_utils.ts": "60cb4ec8bd335bf241ef785ccec51e809d576ff8e8d29da43d2273b69ce2a6ff",
     "https://deno.land/x/deno_cache@0.4.1/auth_tokens.ts": "5fee7e9155e78cedf3f6ff3efacffdb76ac1a76c86978658d9066d4fb0f7326e",

--- a/packages/server/src/deps.ts
+++ b/packages/server/src/deps.ts
@@ -18,7 +18,7 @@ export type {
 } from '../../types/src/index.ts';
 
 // cbor (a.k.a. cbor-x in Node land)
-export * as cborx from 'https://deno.land/x/cbor@v1.5.2/encode.js';
+export * as cborx from 'https://deno.land/x/cbor@v1.5.2/index.js';
 
 // b64 (a.k.a. @hexagon/base64 in Node land)
 export { default as base64 } from 'https://deno.land/x/b64@1.1.27/src/base64.js';


### PR DESCRIPTION
While adding webauthn support to a Next.js app, I kept getting the following error during build:
```
../../../node_modules/.pnpm/cbor-x@1.5.2/node_modules/cbor-x/decode.js
Dynamic Code Evaluation (e. g. 'eval', 'new Function', 'WebAssembly.compile') not allowed in Edge Runtime 
Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation

Import trace for requested module:
../../../node_modules/.pnpm/cbor-x@1.5.2/node_modules/cbor-x/decode.js
../../../node_modules/.pnpm/cbor-x@1.5.2/node_modules/cbor-x/encode.js
../../../node_modules/.pnpm/@simplewebauthn+server@9.0.0/node_modules/@simplewebauthn/server/esm/deps.js
../../../node_modules/.pnpm/@simplewebauthn+server@9.0.0/node_modules/@simplewebauthn/server/esm/registration/verifications/verifyAttestationAndroidKey.js
../../../node_modules/.pnpm/@simplewebauthn+server@9.0.0/node_modules/@simplewebauthn/server/esm/registration/verifyRegistrationResponse.js
../../../node_modules/.pnpm/@simplewebauthn+server@9.0.0/node_modules/@simplewebauthn/server/esm/index.js
```

Turns out `cbor-x` declares some dynamic functions that are not compatible with Vercel's edge compute and Cloudflare workers ([info](https://github.com/cloudflare/workerd/discussions/1432)).

Thankfully, fixing it is fairly straighforward. `cbor-x` exports a version of itself without these eval statements via [`cbor-x/index-no-eval`](https://github.com/kriszyp/cbor-x/blob/e00ba2c0b6ec830ec1afe2cd2a14bb49c8bc9c01/package.json#L59)

I tested the change locally by changing the cbor import line in my node_modules to be
`export * as cborx from 'cbor-x/index-no-eval';`
and it fixed the issue.

The Deno import can continue pointing to the regular export since it supports eval.

PS: a few months ago I merge a PR here for something related - lack of support for streaming APIs in serverless environments. [That has since changed](https://nextjs.org/docs/app/api-reference/edge), so importing from `cbor-x/index` instead of `cbor-x/encode` isn't an issue anymore.