### PR TITLE
Fixed generateAuthenticationOptions

### DIFF
--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -53,7 +53,7 @@ export async function generateAuthenticationOptions(
     challenge: isoBase64URL.fromBuffer(_challenge),
     allowCredentials: allowCredentials?.map((cred) => ({
       ...cred,
-      id: isoBase64URL.fromBuffer(cred.id as Uint8Array),
+      id: typeof(cred.id) !== 'string' ? isoBase64URL.fromBuffer(cred.id as Uint8Array) : cred.id,
     })),
     timeout,
     userVerification,


### PR DESCRIPTION
As discussed [here](https://github.com/MasterKale/SimpleWebAuthn/issues/458) and [here](https://github.com/MasterKale/SimpleWebAuthn/issues/345#issuecomment-1585735973), even though we are storing `credentialID` as a `base64Url`, the `generateAuthenticationOptions` function requires it to be a buffer, and _then_ converts it back to a `base64Url`. 

This PR adds the ability to `generateAuthenticationOptions` to check if it is a string (i.e base64Url) and if it is will return it as is, if it is not a string (i.e it is a buffer) it will go through the existing conversion of buffer to base64Url. This allows users who are storing credentialID as a base64Url (which is recommended), to pass it in directly to generateAuthenticationOptions without having to convert it to a buffer first. 