### PR TITLE
fix/525-tweak-client-data-json-parse-arg-type

### DIFF
--- a/packages/server/src/helpers/decodeClientDataJSON.ts
+++ b/packages/server/src/helpers/decodeClientDataJSON.ts
@@ -1,9 +1,10 @@
 import { isoBase64URL } from './iso/index.ts';
+import type { Base64URLString } from '../deps.ts';
 
 /**
  * Decode an authenticator's base64url-encoded clientDataJSON to JSON
  */
-export function decodeClientDataJSON(data: string): ClientDataJSON {
+export function decodeClientDataJSON(data: Base64URLString): ClientDataJSON {
   const toString = isoBase64URL.toString(data);
   const clientData: ClientDataJSON = JSON.parse(toString);
 


### PR DESCRIPTION
This PR updates typing on the `data` argument of `decodeClientDataJSON()` to communicate that strings containing base64url-encoded values are the intended shape of the string the method currently accepts.

As the `Base64URLString` type is a simple type alias of `string` nothing functionally changes about this method.

Fixes #525.