### PR TITLE
feat/519-raise-minimum-node-version-v20

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -17,9 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16, 18 ]
-        # TODO: Find a better action, this one is limited to v1.33.1
-        # See https://github.com/maximousblk/setup-deno/issues
-        deno-version: [ 'v1.33.1' ]
+        deno-version: [ 'v1.41.0' ]
 
     steps:
     - uses: actions/checkout@v3
@@ -34,7 +32,7 @@ jobs:
 
     # Install Deno
     - name: Setup Deno ${{ matrix.deno-version }}
-      uses: maximousblk/setup-deno@v2
+      uses: denoland/setup-deno@v1
       with:
         deno-version: ${{ matrix.deno-version }}
     - name: Confirm installed Deno version

--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 16, 18 ]
+        node-version: [ 20, 22 ]
         deno-version: [ 'v1.41.0' ]
 
     steps:
@@ -24,7 +24,7 @@ jobs:
 
     # Install Node
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Confirm installed Node version

--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 20, 22 ]
+        node-version: [ 20 ]
         deno-version: [ 'v1.41.0' ]
 
     steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
-  // `deno.enable` is superfluous but necessary pre-Deno 1.37 (we're currently using 1.36)
-  // See https://github.com/denoland/deno/issues/20411#issuecomment-1725920550
-  "deno.enable": true,
   "deno.path": "/opt/homebrew/bin/deno",
   "deno.enablePaths": [
     "./packages/server",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://simplewebauthn.dev/docs/
 
 ## Installation
 
-These packages are all available on **npm** for use in **Node LTS 16.x** projects and supports
+These packages are all available on **npm** for use in **Node LTS 20.x** projects and supports
 **both CommonJS and [ECMAScript modules (ESM)](https://nodejs.org/api/esm.html#enabling)**:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ these types of requests to start this discussion.
 Install the following before proceeding:
 
 - **Node.js 18.x**
-- **Deno 1.36.x**
+- **Deno 1.41.x**
 - **pnpm 8.6.x**
 
 After pulling down the code, set up dependencies:

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/express-session": "^1.17.5",
-        "@types/node": "^16.7.4",
+        "@types/node": "^20.11.20",
         "@types/node-fetch": "^2.5.12",
         "nodemon": "^2.0.12",
         "ts-node": "^10.2.1",
@@ -217,10 +217,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-      "dev": true
+      "version": "20.11.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
+      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.1",
@@ -1461,6 +1464,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1703,10 +1712,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-      "dev": true
+      "version": "20.11.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
+      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.1",
@@ -2647,6 +2659,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unpipe": {

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/express-session": "^1.17.5",
-    "@types/node": "^16.7.4",
+    "@types/node": "^20.11.20",
     "@types/node-fetch": "^2.5.12",
     "nodemon": "^2.0.12",
     "ts-node": "^10.2.1",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -4,14 +4,14 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/server)
 
 - [Installation](#installation)
-  - [Node LTS 16.x or higher](#node-lts-16x-or-higher)
+  - [Node LTS 20.x or higher](#node-lts-20x-or-higher)
   - [Deno v1.33.x or higher](#deno-v133x-or-higher)
 - [Usage](#usage)
 - [Supported Attestation Formats](#supported-attestation-formats)
 
 ## Installation
 
-### Node LTS 16.x or higher
+### Node LTS 20.x or higher
 
 This package is available on **npm** and supports **both CommonJS and
 [ECMAScript modules (ESM)](https://nodejs.org/api/esm.html#enabling)** projects:

--- a/packages/server/build_npm.ts
+++ b/packages/server/build_npm.ts
@@ -41,7 +41,7 @@ await build({
       access: 'public',
     },
     engines: {
-      node: '>=16.0.0',
+      node: '>=20.0.0',
     },
     bugs: {
       url: 'https://github.com/MasterKale/SimpleWebAuthn/issues',

--- a/packages/server/deno.lock
+++ b/packages/server/deno.lock
@@ -1,5 +1,16 @@
 {
-  "version": "2",
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "npm:@types/node": "npm:@types/node@18.16.19"
+    },
+    "npm": {
+      "@types/node@18.16.19": {
+        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+        "dependencies": {}
+      }
+    }
+  },
   "remote": {
     "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
@@ -153,16 +164,5 @@
     "https://esm.sh/v135/pvtsutils@1.3.5/denonext/pvtsutils.mjs": "016782b990e2652a326cf1d8984c2adc4552171da902cc73dc8e12ffdbe3a100",
     "https://esm.sh/v135/pvutils@1.1.3/denonext/pvutils.mjs": "ad156a239ec0f1aa99f123fab44abc292c87d4fd6969d7af264436630457523c",
     "https://esm.sh/v135/tslib@2.6.2/denonext/tslib.mjs": "29782bcd3139f77ec063dc5a9385c0fff4a8d0a23b6765c73d9edeb169a04bf1"
-  },
-  "npm": {
-    "specifiers": {
-      "@types/node": "@types/node@18.16.19"
-    },
-    "packages": {
-      "@types/node@18.16.19": {
-        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-        "dependencies": {}
-      }
-    }
   }
 }

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -6,12 +6,12 @@
 TypeScript typings for **@simplewebauthn/server** and **@simplewebauthn/browser**
 
 - [Installation](#installation)
-  - [Node LTS 16.x or higher](#node-lts-16x-or-higher)
+  - [Node LTS 20.x or higher](#node-lts-20x-or-higher)
   - [Deno v1.33.x or higher](#deno-v133x-or-higher)
 
 ## Installation
 
-### Node LTS 16.x or higher
+### Node LTS 20.x or higher
 
 This package is available on **npm**:
 


### PR DESCRIPTION
This PR raises the minimum Node version to v20+, and now tests against LTS v20.

Deno testing has also been bumped to 1.41.0.

Fixed #519. 