### PR TITLE
Update getWebCrypto for Node 20 (Approach 1)

### DIFF
--- a/packages/server/src/authentication/generateAuthenticationOptions.test.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals, assertExists } from 'https://deno.land/std@0.198.0/assert/mod.ts';
 
-import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
+import { isoBase64URL } from '../helpers/iso/index.ts';
 
 import { generateAuthenticationOptions } from './generateAuthenticationOptions.ts';
 

--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -33,12 +33,12 @@ export type GenerateAuthenticationOptionsOpts = {
  * @param extensions Additional plugins the authenticator or browser should use during authentication
  * @param rpID Valid domain name (after `https://`)
  */
-export async function generateAuthenticationOptions(
+export function generateAuthenticationOptions(
   options: GenerateAuthenticationOptionsOpts = {},
-): Promise<PublicKeyCredentialRequestOptionsJSON> {
+): PublicKeyCredentialRequestOptionsJSON {
   const {
     allowCredentials,
-    challenge = await generateChallenge(),
+    challenge = generateChallenge(),
     timeout = 60000,
     userVerification = 'preferred',
     extensions,

--- a/packages/server/src/helpers/generateChallenge.test.ts
+++ b/packages/server/src/helpers/generateChallenge.test.ts
@@ -2,15 +2,15 @@ import { assert, assertNotEquals } from 'https://deno.land/std@0.198.0/assert/mo
 
 import { generateChallenge } from './generateChallenge.ts';
 
-Deno.test('should return a buffer of at least 32 bytes', async () => {
-  const challenge = await generateChallenge();
+Deno.test('should return a buffer of at least 32 bytes', () => {
+  const challenge = generateChallenge();
 
   assert(challenge.byteLength >= 32);
 });
 
-Deno.test('should return random bytes on each execution', async () => {
-  const challenge1 = await generateChallenge();
-  const challenge2 = await generateChallenge();
+Deno.test('should return random bytes on each execution', () => {
+  const challenge1 = generateChallenge();
+  const challenge2 = generateChallenge();
 
   assertNotEquals(challenge1, challenge2);
 });

--- a/packages/server/src/helpers/generateChallenge.ts
+++ b/packages/server/src/helpers/generateChallenge.ts
@@ -3,7 +3,7 @@ import { isoCrypto } from './iso/index.ts';
 /**
  * Generate a suitably random value to be used as an attestation or assertion challenge
  */
-export async function generateChallenge(): Promise<Uint8Array> {
+export function generateChallenge(): Uint8Array {
   /**
    * WebAuthn spec says that 16 bytes is a good minimum:
    *
@@ -14,7 +14,7 @@ export async function generateChallenge(): Promise<Uint8Array> {
    */
   const challenge = new Uint8Array(32);
 
-  await isoCrypto.getRandomValues(challenge);
+  isoCrypto.getRandomValues(challenge);
 
   return _generateChallengeInternals.stubThis(challenge);
 }

--- a/packages/server/src/helpers/iso/isoCrypto/digest.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/digest.ts
@@ -12,7 +12,7 @@ export async function digest(
   data: Uint8Array,
   algorithm: COSEALG,
 ): Promise<Uint8Array> {
-  const WebCrypto = await getWebCrypto();
+  const WebCrypto = getWebCrypto();
 
   const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
 

--- a/packages/server/src/helpers/iso/isoCrypto/getRandomValues.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getRandomValues.ts
@@ -5,8 +5,8 @@ import { getWebCrypto } from './getWebCrypto.ts';
  *
  * @returns the same bytes array passed into the method
  */
-export async function getRandomValues(array: Uint8Array): Promise<Uint8Array> {
-  const WebCrypto = await getWebCrypto();
+export function getRandomValues(array: Uint8Array): Uint8Array {
+  const WebCrypto = getWebCrypto();
 
   WebCrypto.getRandomValues(array);
 

--- a/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/getWebCrypto.test.ts
@@ -1,9 +1,9 @@
-import { assertEquals, assertRejects } from 'https://deno.land/std@0.198.0/assert/mod.ts';
+import { assertEquals, assertThrows } from 'https://deno.land/std@0.198.0/assert/mod.ts';
 import { returnsNext, stub } from 'https://deno.land/std@0.198.0/testing/mock.ts';
 
 import { _getWebCryptoInternals, getWebCrypto, MissingWebCrypto } from './getWebCrypto.ts';
 
-Deno.test('should return globalThis.crypto when present', async () => {
+Deno.test('should return globalThis.crypto when present', () => {
   // Clear whatever version of crypto might have been set
   _getWebCryptoInternals.setCachedCrypto(undefined);
 
@@ -16,14 +16,14 @@ Deno.test('should return globalThis.crypto when present', async () => {
     returnsNext([newGlobalThisCrypto]),
   );
 
-  const returnedCrypto = await getWebCrypto();
+  const returnedCrypto = getWebCrypto();
 
   assertEquals(returnedCrypto, newGlobalThisCrypto);
 
   mockGlobalThisCrypto.restore();
 });
 
-Deno.test('should return node:crypto.webcrypto when globalThis.crypto is missing', async () => {
+Deno.test('should raise MissingWebCrypto error when nothing is available', () => {
   // Clear whatever version of crypto might have been set
   _getWebCryptoInternals.setCachedCrypto(undefined);
 
@@ -35,115 +35,11 @@ Deno.test('should return node:crypto.webcrypto when globalThis.crypto is missing
     returnsNext([undefined]),
   );
 
-  // Mock out just enough of the 'node:crypto' module
-  const fakeNodeCrypto = { webcrypto: {} };
-  const mockImportNodeCrypto = stub(
-    _getWebCryptoInternals,
-    'stubThisImportNodeCrypto',
-    // @ts-ignore: node:crypto
-    returnsNext([Promise.resolve(fakeNodeCrypto)]),
-  );
-
-  const returnedCrypto = await getWebCrypto();
-
-  assertEquals(returnedCrypto, fakeNodeCrypto.webcrypto);
-
-  mockGlobalThisCrypto.restore();
-  mockImportNodeCrypto.restore();
-});
-
-Deno.test(
-  'should return globalThis.crypto when present, while node:crypto.webcrypto is present',
-  async () => {
-    // Clear whatever version of crypto might have been set
-    _getWebCryptoInternals.setCachedCrypto(undefined);
-
-    // Pretend globalThis.crypto exists
-    const fakeGlobalThisCrypto = {};
-    const mockGlobalThisCrypto = stub(
-      _getWebCryptoInternals,
-      'stubThisGlobalThisCrypto',
-      // @ts-ignore: globalThis.crypto
-      returnsNext([fakeGlobalThisCrypto]),
-    );
-
-    // Mock out just enough of the 'node:crypto' module, but like we're in Node v14
-    const fakeNodeCrypto = { webcrypto: {} };
-    const mockImportNodeCrypto = stub(
-      _getWebCryptoInternals,
-      'stubThisImportNodeCrypto',
-      // @ts-ignore: node:crypto
-      returnsNext([Promise.resolve(fakeNodeCrypto)]),
-    );
-
-    const returnedCrypto = await getWebCrypto();
-
-    assertEquals(returnedCrypto, fakeGlobalThisCrypto);
-
-    mockGlobalThisCrypto.restore();
-    mockImportNodeCrypto.restore();
-  },
-);
-
-Deno.test(
-  'should return globalThis.crypto when present, while node:crypto is present but missing webcrypto',
-  async () => {
-    // Clear whatever version of crypto might have been set
-    _getWebCryptoInternals.setCachedCrypto(undefined);
-
-    // Pretend globalThis.crypto exists
-    const fakeGlobalThisCrypto = {};
-    const mockGlobalThisCrypto = stub(
-      _getWebCryptoInternals,
-      'stubThisGlobalThisCrypto',
-      // @ts-ignore: globalThis.crypto
-      returnsNext([fakeGlobalThisCrypto]),
-    );
-
-    // Mock out just enough of the 'node:crypto' module, but like we're in Node v14
-    const fakeNodeCrypto = { webcrypto: undefined };
-    const mockImportNodeCrypto = stub(
-      _getWebCryptoInternals,
-      'stubThisImportNodeCrypto',
-      // @ts-ignore: node:crypto
-      returnsNext([Promise.resolve(fakeNodeCrypto)]),
-    );
-
-    const returnedCrypto = await getWebCrypto();
-
-    assertEquals(returnedCrypto, fakeGlobalThisCrypto);
-
-    mockGlobalThisCrypto.restore();
-    mockImportNodeCrypto.restore();
-  },
-);
-
-Deno.test('should raise MissingWebCrypto error when nothing is available', async () => {
-  // Clear whatever version of crypto might have been set
-  _getWebCryptoInternals.setCachedCrypto(undefined);
-
-  // Pretend globalThis.crypto doesn't exist
-  const mockGlobalThisCrypto = stub(
-    _getWebCryptoInternals,
-    'stubThisGlobalThisCrypto',
-    // @ts-ignore: globalThis.crypto
-    returnsNext([undefined]),
-  );
-
-  // Pretend node:crypto doesn't exist
-  const mockImportNodeCrypto = stub(
-    _getWebCryptoInternals,
-    'stubThisImportNodeCrypto',
-    // @ts-ignore: node:crypto
-    returnsNext([Promise.resolve({ webcrypto: undefined })]),
-  );
-
-  await assertRejects(
+  assertThrows(
     () => getWebCrypto(),
     MissingWebCrypto,
     'Crypto API could not be located',
   );
 
   mockGlobalThisCrypto.restore();
-  mockImportNodeCrypto.restore();
 });

--- a/packages/server/src/helpers/iso/isoCrypto/importKey.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/importKey.ts
@@ -1,10 +1,10 @@
 import { getWebCrypto } from './getWebCrypto.ts';
 
-export async function importKey(opts: {
+export function importKey(opts: {
   keyData: JsonWebKey;
   algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams;
 }): Promise<CryptoKey> {
-  const WebCrypto = await getWebCrypto();
+  const WebCrypto = getWebCrypto();
 
   const { keyData, algorithm } = opts;
 

--- a/packages/server/src/helpers/iso/isoCrypto/verifyEC2.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyEC2.ts
@@ -16,7 +16,7 @@ export async function verifyEC2(opts: {
 }): Promise<boolean> {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
 
-  const WebCrypto = await getWebCrypto();
+  const WebCrypto = getWebCrypto();
 
   // Import the public key
   const alg = cosePublicKey.get(COSEKEYS.alg);

--- a/packages/server/src/helpers/iso/isoCrypto/verifyOKP.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyOKP.ts
@@ -11,7 +11,7 @@ export async function verifyOKP(opts: {
 }): Promise<boolean> {
   const { cosePublicKey, signature, data } = opts;
 
-  const WebCrypto = await getWebCrypto();
+  const WebCrypto = getWebCrypto();
 
   const alg = cosePublicKey.get(COSEKEYS.alg);
   const crv = cosePublicKey.get(COSEKEYS.crv);

--- a/packages/server/src/helpers/iso/isoCrypto/verifyRSA.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyRSA.ts
@@ -16,7 +16,7 @@ export async function verifyRSA(opts: {
 }): Promise<boolean> {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
 
-  const WebCrypto = await getWebCrypto();
+  const WebCrypto = getWebCrypto();
 
   const alg = cosePublicKey.get(COSEKEYS.alg);
   const n = cosePublicKey.get(COSEKEYS.n);

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -3,7 +3,6 @@ import { returnsNext, stub } from 'https://deno.land/std@0.198.0/testing/mock.ts
 
 import { generateRegistrationOptions } from './generateRegistrationOptions.ts';
 import { _generateChallengeInternals } from '../helpers/generateChallenge.ts';
-import { isoUint8Array } from '../helpers/iso/index.ts';
 
 Deno.test('should generate credential request options suitable for sending via JSON', async () => {
   const rpName = 'SimpleWebAuthn';

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -98,15 +98,15 @@ const defaultSupportedAlgorithmIDs: COSEAlgorithmIdentifier[] = [-8, -7, -257];
  * @param supportedAlgorithmIDs Array of numeric COSE algorithm identifiers supported for
  * attestation by this RP. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  */
-export async function generateRegistrationOptions(
+export function generateRegistrationOptions(
   options: GenerateRegistrationOptionsOpts,
-): Promise<PublicKeyCredentialCreationOptionsJSON> {
+): PublicKeyCredentialCreationOptionsJSON {
   const {
     rpName,
     rpID,
     userID,
     userName,
-    challenge = await generateChallenge(),
+    challenge = generateChallenge(),
     userDisplayName = userName,
     timeout = 60000,
     attestationType = 'none',

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -857,7 +857,7 @@ Deno.test('should fail verification if custom challenge verifier returns a Promi
     () =>
       verifyRegistrationResponse({
         response: attestationNone,
-        expectedChallenge: (challenge: string) => Promise.reject(new Error('rejected')),
+        expectedChallenge: (_: string) => Promise.reject(new Error('rejected')),
         expectedOrigin: 'https://dev.dontneeda.pw',
         expectedRPID: 'dev.dontneeda.pw',
       }),


### PR DESCRIPTION
This PR updates `getWebCrypto()` to access `globalThis.crypto` exclusively since Node 20 supports this as a stable API access points. No attempts are made to import from `node:crypto` anymore.

This is a **bigger** PR because `getWebCrypto()` becomes synchronous, which spiders out into a few files that use `WebCrypto`. I hope I don't regret this...

Fixes #532.