### PR TITLE
fix(browser): handle undefined PublicKeyCredential in browserSupportsWebAuthnAutofill helper

### DIFF
--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -1,10 +1,16 @@
-import { PublicKeyCredentialFuture } from '@simplewebauthn/types';
+import { PublicKeyCredentialFuture } from "@simplewebauthn/types";
+
+import { browserSupportsWebAuthn } from "./browserSupportsWebAuthn";
 
 /**
  * Determine if the browser supports conditional UI, so that WebAuthn credentials can
  * be shown to the user in the browser's typical password autofill popup.
  */
 export function browserSupportsWebAuthnAutofill(): Promise<boolean> {
+  if (!browserSupportsWebAuthn()) {
+    return new Promise((resolve) => resolve(false));
+  }
+
   /**
    * I don't like the `as unknown` here but there's a `declare var PublicKeyCredential` in
    * TS' DOM lib that's making it difficult for me to just go `as PublicKeyCredentialFuture` as I


### PR DESCRIPTION
This PR adds an early return to the `browserSupportsWebAuthnAutofill` helper function if `browserSupportsWebAuthn` returns false. This prevents `browserSupportsWebAuthnAutofill` from throwing a `TypeError` on browsers without webauthn support.

Closes #544 