### PR TITLE
fix/544-ensure-webauthn-available-autofill-feature-check

### DIFF
--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.test.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.test.ts
@@ -1,0 +1,35 @@
+import { browserSupportsWebAuthnAutofill } from './browserSupportsWebAuthnAutofill';
+
+// Mock "isConditionalMediationAvailable"
+const mockICMA = jest.fn();
+
+beforeEach(() => {
+  mockICMA.mockReset();
+
+  // @ts-ignore 2741
+  window.PublicKeyCredential = jest.fn().mockReturnValue(() => {});
+  window.PublicKeyCredential.isConditionalMediationAvailable = mockICMA
+    .mockResolvedValue(true);
+});
+
+test('should return true when conditional mediation is supported', async () => {
+  const supportsAutofill = await browserSupportsWebAuthnAutofill();
+
+  expect(supportsAutofill).toEqual(true);
+});
+
+test('should return false when conditional mediation is not supported', async () => {
+  mockICMA.mockResolvedValue(false);
+
+  const supportsAutofill = await browserSupportsWebAuthnAutofill();
+
+  expect(supportsAutofill).toEqual(false);
+});
+
+test('should return false when browser does not support WebAuthn', async () => {
+  // This looks weird but it appeases the linter so it's _fiiiine_
+  delete (window as { PublicKeyCredential: unknown }).PublicKeyCredential;
+  const supportsAutofill = await browserSupportsWebAuthnAutofill();
+
+  expect(supportsAutofill).toEqual(false);
+});

--- a/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
+++ b/packages/browser/src/helpers/browserSupportsWebAuthnAutofill.ts
@@ -1,10 +1,16 @@
 import { PublicKeyCredentialFuture } from '@simplewebauthn/types';
 
+import { browserSupportsWebAuthn } from './browserSupportsWebAuthn';
+
 /**
  * Determine if the browser supports conditional UI, so that WebAuthn credentials can
  * be shown to the user in the browser's typical password autofill popup.
  */
 export function browserSupportsWebAuthnAutofill(): Promise<boolean> {
+  if (!browserSupportsWebAuthn()) {
+    return new Promise((resolve) => resolve(false));
+  }
+
   /**
    * I don't like the `as unknown` here but there's a `declare var PublicKeyCredential` in
    * TS' DOM lib that's making it difficult for me to just go `as PublicKeyCredentialFuture` as I


### PR DESCRIPTION
This PR updates **@simplewebauthn/browser**'s `browserSupportsWebAuthnAutofill()` method to first ensure that WebAuthn is available.

Fixes #544.