### PR TITLE
Fix ECDSA Signature Unwrapping

### DIFF
--- a/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
@@ -56,7 +56,7 @@ function toNormalizedBytes(i: ArrayBuffer, n: number): Uint8Array {
   const normalizedBytes = new Uint8Array(n);
   if (iBytes.length <= n) {
     normalizedBytes.set(iBytes, n - iBytes.length);
-  } else if (iBytes.length === n + 1 && iBytes[0] === 0) {
+  } else if (iBytes.length === n + 1 && iBytes[0] === 0 && (iBytes[1] & 0x80) === 0x80) {
     normalizedBytes.set(iBytes.slice(1));
   } else {
     throw new Error("invalid signature component length");

--- a/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
@@ -9,19 +9,25 @@ import { isoUint8Array } from '../index.ts';
  */
 export function unwrapEC2Signature(signature: Uint8Array, crv: COSECRV): Uint8Array {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
-  const n = getSignatureComponentLength(crv);
+  const rBytes = new Uint8Array(parsedSignature.r);
+  const sBytes = new Uint8Array(parsedSignature.s);
 
-  const rBytes = toNormalizedBytes(parsedSignature.r, n);
-  const sBytes = toNormalizedBytes(parsedSignature.s, n);
+  const componentLength = getSignatureComponentLength(crv);
+  const rNormalizedBytes = toNormalizedBytes(rBytes, componentLength);
+  const sNormalizedBytes = toNormalizedBytes(sBytes, componentLength);
 
-  const finalSignature = isoUint8Array.concat([rBytes, sBytes]);
+  const finalSignature = isoUint8Array.concat([
+    rNormalizedBytes,
+    sNormalizedBytes,
+  ]);
 
   return finalSignature;
 }
 
 /**
- * ECDSA signatures with in the subtle crypto API expect signatures with `r` and `s` values
- * encoded to a specific length depending on the order of the curve.
+ * The SubtleCrypto Web Crypto API expects ECDSA signatures with `r` and `s` values to be encoded
+ * to a specific length depending on the order of the curve. This function returns the expected
+ * byte-length for each of the `r` and `s` signature components.
  *
  * See <https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations>
  */
@@ -42,24 +48,28 @@ function getSignatureComponentLength(crv: COSECRV): number {
  * Converts the ASN.1 integer representation to bytes of a specific length `n`.
  *
  * DER encodes integers as big-endian byte arrays, with as small as possible representation and
- * require leading `0` bytes to disambiguate between negative and positive numbers. This means
- * that `r` and `s` can potentially not be the expected length `n` that is needed by the WebCrypto
- * subtle API: if there it leading `0`s it can be shorter than expected, and if it has a leading
- * `1` bit, it can be one byte longer.
+ * requires a leading `0` byte to disambiguate between negative and positive numbers. This means
+ * that `r` and `s` can potentially not be the expected byte-length that is needed by the
+ * SubtleCrypto Web Crypto API: if there are leading `0`s it can be shorter than expected, and if
+ * it has a leading `1` bit, it can be one byte longer.
  *
  * See <https://www.itu.int/rec/T-REC-X.690-202102-I/en>
  * See <https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations>
  */
-function toNormalizedBytes(i: ArrayBuffer, n: number): Uint8Array {
-  const iBytes = new Uint8Array(i);
-
-  const normalizedBytes = new Uint8Array(n);
-  if (iBytes.length <= n) {
-    normalizedBytes.set(iBytes, n - iBytes.length);
-  } else if (iBytes.length === n + 1 && iBytes[0] === 0 && (iBytes[1] & 0x80) === 0x80) {
-    normalizedBytes.set(iBytes.slice(1));
+function toNormalizedBytes(bytes: Uint8Array, componentLength: number): Uint8Array {
+  let normalizedBytes;
+  if (bytes.length < componentLength) {
+    // In case the bytes are shorter than expected, we need to pad it with leading `0`s.
+    normalizedBytes = new Uint8Array(componentLength);
+    normalizedBytes.set(bytes, componentLength - bytes.length);
+  } else if (bytes.length === componentLength) {
+    normalizedBytes = bytes;
+  } else if (bytes.length === componentLength + 1 && bytes[0] === 0 && (bytes[1] & 0x80) === 0x80) {
+    // The bytes contain a leading `0` to encode that the integer is positive. This leading `0`
+    // needs to be removed for compatibility with the SubtleCrypto Web Crypto API.
+    normalizedBytes = bytes.subarray(1);
   } else {
-    throw new Error("invalid signature component length");
+    throw new Error(`invalid signature component length ${bytes.length} (expected ${componentLength})`);
   }
 
   return normalizedBytes;

--- a/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
@@ -1,4 +1,5 @@
 import { AsnParser, ECDSASigValue } from '../../../deps.ts';
+import { COSECRV } from '../../cose.ts';
 import { isoUint8Array } from '../index.ts';
 
 /**
@@ -6,18 +7,12 @@ import { isoUint8Array } from '../index.ts';
  *
  * See https://www.w3.org/TR/webauthn-2/#sctn-signature-attestation-types
  */
-export function unwrapEC2Signature(signature: Uint8Array): Uint8Array {
+export function unwrapEC2Signature(signature: Uint8Array, crv: COSECRV): Uint8Array {
   const parsedSignature = AsnParser.parse(signature, ECDSASigValue);
-  let rBytes = new Uint8Array(parsedSignature.r);
-  let sBytes = new Uint8Array(parsedSignature.s);
+  const n = getSignatureComponentLength(crv);
 
-  if (shouldRemoveLeadingZero(rBytes)) {
-    rBytes = rBytes.slice(1);
-  }
-
-  if (shouldRemoveLeadingZero(sBytes)) {
-    sBytes = sBytes.slice(1);
-  }
+  const rBytes = toNormalizedBytes(parsedSignature.r, n);
+  const sBytes = toNormalizedBytes(parsedSignature.s, n);
 
   const finalSignature = isoUint8Array.concat([rBytes, sBytes]);
 
@@ -25,12 +20,47 @@ export function unwrapEC2Signature(signature: Uint8Array): Uint8Array {
 }
 
 /**
- * Determine if the DER-specific `00` byte at the start of an ECDSA signature byte sequence
- * should be removed based on the following logic:
+ * ECDSA signatures with in the subtle crypto API expect signatures with `r` and `s` values
+ * encoded to a specific length depending on the order of the curve.
  *
- * "If the leading byte is 0x0, and the the high order bit on the second byte is not set to 0,
- * then remove the leading 0x0 byte"
+ * See <https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations>
  */
-function shouldRemoveLeadingZero(bytes: Uint8Array): boolean {
-  return bytes[0] === 0x0 && (bytes[1] & (1 << 7)) !== 0;
+function getSignatureComponentLength(crv: COSECRV): number {
+  switch (crv) {
+  case COSECRV.P256:
+    return 32;
+  case COSECRV.P384:
+    return 48;
+  case COSECRV.P521:
+    return 66;
+  default:
+    throw new Error(`Unexpected COSE crv value of ${crv} (EC2)`);
+  }
+}
+
+/**
+ * Converts the ASN.1 integer representation to bytes of a specific length `n`.
+ *
+ * DER encodes integers as big-endian byte arrays, with as small as possible representation and
+ * require leading `0` bytes to disambiguate between negative and positive numbers. This means
+ * that `r` and `s` can potentially not be the expected length `n` that is needed by the WebCrypto
+ * subtle API: if there it leading `0`s it can be shorter than expected, and if it has a leading
+ * `1` bit, it can be one byte longer.
+ *
+ * See <https://www.itu.int/rec/T-REC-X.690-202102-I/en>
+ * See <https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations>
+ */
+function toNormalizedBytes(i: ArrayBuffer, n: number): Uint8Array {
+  const iBytes = new Uint8Array(i);
+
+  const normalizedBytes = new Uint8Array(n);
+  if (iBytes.length <= n) {
+    normalizedBytes.set(iBytes, n - iBytes.length);
+  } else if (iBytes.length === n + 1 && iBytes[0] === 0) {
+    normalizedBytes.set(iBytes.slice(1));
+  } else {
+    throw new Error("invalid signature component length");
+  }
+
+  return normalizedBytes;
 }

--- a/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/unwrapEC2Signature.ts
@@ -33,14 +33,14 @@ export function unwrapEC2Signature(signature: Uint8Array, crv: COSECRV): Uint8Ar
  */
 function getSignatureComponentLength(crv: COSECRV): number {
   switch (crv) {
-  case COSECRV.P256:
-    return 32;
-  case COSECRV.P384:
-    return 48;
-  case COSECRV.P521:
-    return 66;
-  default:
-    throw new Error(`Unexpected COSE crv value of ${crv} (EC2)`);
+    case COSECRV.P256:
+      return 32;
+    case COSECRV.P384:
+      return 48;
+    case COSECRV.P521:
+      return 66;
+    default:
+      throw new Error(`Unexpected COSE crv value of ${crv} (EC2)`);
   }
 }
 
@@ -69,7 +69,9 @@ function toNormalizedBytes(bytes: Uint8Array, componentLength: number): Uint8Arr
     // needs to be removed for compatibility with the SubtleCrypto Web Crypto API.
     normalizedBytes = bytes.subarray(1);
   } else {
-    throw new Error(`invalid signature component length ${bytes.length} (expected ${componentLength})`);
+    throw new Error(
+      `invalid signature component length ${bytes.length} (expected ${componentLength})`,
+    );
   }
 
   return normalizedBytes;

--- a/packages/server/src/helpers/iso/isoCrypto/verify.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verify.ts
@@ -2,6 +2,7 @@ import {
   COSEALG,
   COSEKEYS,
   COSEPublicKey,
+  isCOSECrv,
   isCOSEPublicKeyEC2,
   isCOSEPublicKeyOKP,
   isCOSEPublicKeyRSA,
@@ -23,7 +24,11 @@ export function verify(opts: {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;
 
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
-    const unwrappedSignature = unwrapEC2Signature(signature);
+    const crv = cosePublicKey.get(COSEKEYS.crv);
+    if (!isCOSECrv(crv)) {
+      throw new Error("unknown COSE curve");
+    }
+    const unwrappedSignature = unwrapEC2Signature(signature, crv);
     return verifyEC2({
       cosePublicKey,
       signature: unwrappedSignature,

--- a/packages/server/src/helpers/iso/isoCrypto/verify.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verify.ts
@@ -26,7 +26,7 @@ export function verify(opts: {
   if (isCOSEPublicKeyEC2(cosePublicKey)) {
     const crv = cosePublicKey.get(COSEKEYS.crv);
     if (!isCOSECrv(crv)) {
-      throw new Error("unknown COSE curve");
+      throw new Error(`unknown COSE curve ${crv}`);
     }
     const unwrappedSignature = unwrapEC2Signature(signature, crv);
     return verifyEC2({

--- a/packages/server/src/helpers/iso/isoCrypto/verifyEC2.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyEC2.test.ts
@@ -23,7 +23,7 @@ Deno.test(
 
     const data = isoBase64URL.toBuffer('Bt81jmu3ieajF4w1at8HmieVOTDymHd7xJguJCUsL-Q');
     const signature = isoBase64URL.toBuffer(
-      'MEQCH1h_F7TPTMVh_kwb_ssjD0_2U77bbXazz2ux-P6khLQCIQCutHs9eCBkCIMP3yA9mmNRKEfFd-REmhGY2GbHozaC7w'
+      'MEQCH1h_F7TPTMVh_kwb_ssjD0_2U77bbXazz2ux-P6khLQCIQCutHs9eCBkCIMP3yA9mmNRKEfFd-REmhGY2GbHozaC7w',
     );
 
     const verified = await verifyEC2({
@@ -54,7 +54,7 @@ Deno.test(
 
     const data = isoBase64URL.toBuffer('D7mI8UwWXv4rpfSQUNqtUXAhZEPbRLugmWclPpJ9m7c');
     const signature = isoBase64URL.toBuffer(
-      'MGMCL3lZ2Rjxo5WcmTCdWyB6jTE9PVuduOR_AsJu956J9S_mFNbHP_-MbyWem4dfb5iqAjABJhTRltNl5Y0O4XC7YLNsYKq2WxYQ1HFOMGsr6oNkUPsX3UAr2zeeWL_Tp1VgHeM'
+      'MGMCL3lZ2Rjxo5WcmTCdWyB6jTE9PVuduOR_AsJu956J9S_mFNbHP_-MbyWem4dfb5iqAjABJhTRltNl5Y0O4XC7YLNsYKq2WxYQ1HFOMGsr6oNkUPsX3UAr2zeeWL_Tp1VgHeM',
     );
 
     const verified = await verifyEC2({
@@ -79,16 +79,20 @@ Deno.test({
     cosePublicKey.set(COSEKEYS.crv, COSECRV.P521);
     cosePublicKey.set(
       COSEKEYS.x,
-      isoBase64URL.toBuffer('AaLbnrCvCuQivbknRW50FjdqPQv4NRF9tHsN4QuVQ3sw8uSspd33o-NTBfjg5JzX9rnpbkKDigb6NugmrVjzNMNK'),
+      isoBase64URL.toBuffer(
+        'AaLbnrCvCuQivbknRW50FjdqPQv4NRF9tHsN4QuVQ3sw8uSspd33o-NTBfjg5JzX9rnpbkKDigb6NugmrVjzNMNK',
+      ),
     );
     cosePublicKey.set(
       COSEKEYS.y,
-      isoBase64URL.toBuffer('AE64axa8L8PkLX5Td0GaX79cLOW9E2-8-ObhL9XT_ih-1XxbGQcA5VhL1gI0xIQq5zYAxgZYey6PmbbqgtcUPRVt'),
+      isoBase64URL.toBuffer(
+        'AE64axa8L8PkLX5Td0GaX79cLOW9E2-8-ObhL9XT_ih-1XxbGQcA5VhL1gI0xIQq5zYAxgZYey6PmbbqgtcUPRVt',
+      ),
     );
 
     const data = isoBase64URL.toBuffer('5p0h9RZTjLoBlnL2nY5pqOnhGy4q60NzbjDe2rVDR7o');
     const signature = isoBase64URL.toBuffer(
-      'MIGHAkFRpbGknlgpETORypMprGBXMkJMfuqgJupy3NcgCOaJJdj3Voz74kV2pjPqkLNpuO9FqVtXeEsUw-jYsBHcMqHZhwJCAQ88uFDJS5g81XVBcLMIgf6ro-F-5jgRAmHx3CRVNGdk81MYbFJhT3hd2w9RdhT8qBG0zzRBXYAcHrKo0qJwQZot'
+      'MIGHAkFRpbGknlgpETORypMprGBXMkJMfuqgJupy3NcgCOaJJdj3Voz74kV2pjPqkLNpuO9FqVtXeEsUw-jYsBHcMqHZhwJCAQ88uFDJS5g81XVBcLMIgf6ro-F-5jgRAmHx3CRVNGdk81MYbFJhT3hd2w9RdhT8qBG0zzRBXYAcHrKo0qJwQZot',
     );
 
     const verified = await verifyEC2({

--- a/packages/server/src/helpers/iso/isoCrypto/verifyEC2.test.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyEC2.test.ts
@@ -1,0 +1,102 @@
+import { assert } from 'https://deno.land/std@0.198.0/assert/mod.ts';
+
+import { COSEALG, COSECRV, COSEKEYS, COSEKTY, COSEPublicKeyEC2 } from '../../cose.ts';
+import { verifyEC2 } from './verifyEC2.ts';
+import { unwrapEC2Signature } from './unwrapEC2Signature.ts';
+import { isoBase64URL } from '../index.ts';
+
+Deno.test(
+  'should verify a signature signed with an P-256 public key',
+  async () => {
+    const cosePublicKey: COSEPublicKeyEC2 = new Map();
+    cosePublicKey.set(COSEKEYS.kty, COSEKTY.EC2);
+    cosePublicKey.set(COSEKEYS.alg, COSEALG.ES256);
+    cosePublicKey.set(COSEKEYS.crv, COSECRV.P256);
+    cosePublicKey.set(
+      COSEKEYS.x,
+      isoBase64URL.toBuffer('_qRi-kwOVobsqJ_1GAHZYfC77QoIdsVFYkx2Mw20UM4'),
+    );
+    cosePublicKey.set(
+      COSEKEYS.y,
+      isoBase64URL.toBuffer('BXEathwyOK_uQRmlZ_m4wReHLujSXk_-e3-9co5B2MY'),
+    );
+
+    const data = isoBase64URL.toBuffer('Bt81jmu3ieajF4w1at8HmieVOTDymHd7xJguJCUsL-Q');
+    const signature = isoBase64URL.toBuffer(
+      'MEQCH1h_F7TPTMVh_kwb_ssjD0_2U77bbXazz2ux-P6khLQCIQCutHs9eCBkCIMP3yA9mmNRKEfFd-REmhGY2GbHozaC7w'
+    );
+
+    const verified = await verifyEC2({
+      cosePublicKey,
+      data,
+      signature: unwrapEC2Signature(signature, COSECRV.P256),
+    });
+
+    assert(verified);
+  },
+);
+
+Deno.test(
+  'should verify a signature signed with an P-384 public key',
+  async () => {
+    const cosePublicKey: COSEPublicKeyEC2 = new Map();
+    cosePublicKey.set(COSEKEYS.kty, COSEKTY.EC2);
+    cosePublicKey.set(COSEKEYS.alg, COSEALG.ES384);
+    cosePublicKey.set(COSEKEYS.crv, COSECRV.P384);
+    cosePublicKey.set(
+      COSEKEYS.x,
+      isoBase64URL.toBuffer('pm-0exykk1x0O72S9sm6fl-iXxFrGikjQHi1CgONIiEz_yDJdCPxN453qg6HLkOx'),
+    );
+    cosePublicKey.set(
+      COSEKEYS.y,
+      isoBase64URL.toBuffer('2B7yW7sgza8Sf7ifznQlGJqmJxgupkAevUqqOJTWaWBZiQ7sAf-TfAaNBukiz12K'),
+    );
+
+    const data = isoBase64URL.toBuffer('D7mI8UwWXv4rpfSQUNqtUXAhZEPbRLugmWclPpJ9m7c');
+    const signature = isoBase64URL.toBuffer(
+      'MGMCL3lZ2Rjxo5WcmTCdWyB6jTE9PVuduOR_AsJu956J9S_mFNbHP_-MbyWem4dfb5iqAjABJhTRltNl5Y0O4XC7YLNsYKq2WxYQ1HFOMGsr6oNkUPsX3UAr2zeeWL_Tp1VgHeM'
+    );
+
+    const verified = await verifyEC2({
+      cosePublicKey,
+      data,
+      signature: unwrapEC2Signature(signature, COSECRV.P384),
+    });
+
+    assert(verified);
+  },
+);
+
+Deno.test({
+  // This test is currently ignored, as Deno's implementation of `WebCrypto.subtle` API does not
+  // support the P-521 curve at the moment.
+  ignore: true,
+  name: 'should verify a signature signed with an P-521 public key',
+  async fn() {
+    const cosePublicKey: COSEPublicKeyEC2 = new Map();
+    cosePublicKey.set(COSEKEYS.kty, COSEKTY.EC2);
+    cosePublicKey.set(COSEKEYS.alg, COSEALG.ES512);
+    cosePublicKey.set(COSEKEYS.crv, COSECRV.P521);
+    cosePublicKey.set(
+      COSEKEYS.x,
+      isoBase64URL.toBuffer('AaLbnrCvCuQivbknRW50FjdqPQv4NRF9tHsN4QuVQ3sw8uSspd33o-NTBfjg5JzX9rnpbkKDigb6NugmrVjzNMNK'),
+    );
+    cosePublicKey.set(
+      COSEKEYS.y,
+      isoBase64URL.toBuffer('AE64axa8L8PkLX5Td0GaX79cLOW9E2-8-ObhL9XT_ih-1XxbGQcA5VhL1gI0xIQq5zYAxgZYey6PmbbqgtcUPRVt'),
+    );
+
+    const data = isoBase64URL.toBuffer('5p0h9RZTjLoBlnL2nY5pqOnhGy4q60NzbjDe2rVDR7o');
+    const signature = isoBase64URL.toBuffer(
+      'MIGHAkFRpbGknlgpETORypMprGBXMkJMfuqgJupy3NcgCOaJJdj3Voz74kV2pjPqkLNpuO9FqVtXeEsUw-jYsBHcMqHZhwJCAQ88uFDJS5g81XVBcLMIgf6ro-F-5jgRAmHx3CRVNGdk81MYbFJhT3hd2w9RdhT8qBG0zzRBXYAcHrKo0qJwQZot'
+    );
+
+    const verified = await verifyEC2({
+      cosePublicKey,
+      data,
+      signature: unwrapEC2Signature(signature, COSECRV.P521),
+    });
+
+    assert(verified);
+  },
+});


### PR DESCRIPTION
We ran into some unexpected and inconsistent signature verification errors. After some digging I traced it down to what I believe is an issue in the `unwrapEC2Signature` method.

From what I understood, this is responsible for taking the ASN.1 encoded ECDSA signature, and encoding it into a format that the WebCrypto library expects (which is `r ‖ s` - where `‖` is the byte concatenation operator). In particular the Web Crypto API documents[^1] that:

> 4. Let `n` be the smallest integer such that `n * 8` is greater than the logarithm to base 2 of the order of the base point of the elliptic curve identified by `params`.
> 5. Convert `r` to an octet string of length `n` and append this sequence of bytes to `result`.
> 6. Convert `s` to an octet string of length `n` and append this sequence of bytes to `result`.

So, this means that the signature components have very specific expected byte lengths when "unwrapping" the signature for use with the Web Crypto "subtle" API. In practice, I found that it was not always producing signatures of the correct length, and in particular the `rBytes` and `sBytes` values were not always of length `n` as defined above. Specifically, I was working with P-256 signatures and noticed that sometimes `r` and/or `s` had a length of 31 instead of 32 (which is the smallest byte-length required to represent an integer equal to the order of the P-256 curve).

Looking into ASN.1 specification[^2]:

> **8.3.2** If the contents octets of an integer value encoding consist of more than one octet, then the bits of the first octet and bit 8 of the second octet:
> 1. shall not all be ones; and
> 2. shall not all be zero.
>
> _NOTE – These rules ensure that an integer value is always encoded in the smallest possible number of octets._

After more closely inspecting the signature I was using, it would occasionally produce signatures where the MSB of the `r` or `s` value was `0`, which would cause the BER encoding of the signature component to be shorter than expected. From the P-256 test case, the signature in hex can be broken down to:

```
# SEQUENCE(03) of length 0x44(68)
30 44
# INTEGER(03) of length 0x1f(31)
02 1f 587f17b4cf4cc561fe4c1bfecb230f4ff653bedb6d76b3cf6bb1f8fea484b4
# INTEGER(03) of length 0x31(33)
02 21 00aeb47b3d78206408830fdf203d9a63512847c577e4449a1198d866c7a33682ef
```

Note that, the leading `00` byte from the signature `r` value is removed in the ASN.1 encoding, while an additional leading `00` byte is added to the `s` value (so that it isn't confused with `02 20 aeb47b3d78206408830fdf203d9a63512847c577e4449a1198d866c7a33682ef`, which would represent `-0x514b84c287df9bf77cf020dfc2659caed7b83a881bbb65ee672799385cc97d11`).

This PR fixes the `unwrapEC2Signature` implementation in order such that it computes `r ‖ s` where the byte length of `r` and `s` are guaranteed to be the same (and specifically `n` as it is defined in the Web Crypto API specification[^1]).

I added some test vectors to make sure things work (that would fail on `master`). I also added a P-521 test vector which does not work (as it does not seem to be implemented by Deno). I left it in as `ignored` as the vector itself should be correct (as manually porting the test to run in my browser passed) and it might be nice to add once P-521 is supported.

[^1]: <https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations>
[^2]: <https://www.itu.int/rec/T-REC-X.690-202102-I/en>