### PR TITLE
Add second TPM manufacturer entry for IBM

### DIFF
--- a/packages/server/src/registration/verifications/tpm/constants.ts
+++ b/packages/server/src/registration/verifications/tpm/constants.ts
@@ -118,6 +118,10 @@ export const TPM_MANUFACTURERS: { [key: string]: ManufacturerInfo } = {
     name: 'IBM',
     id: 'IBM',
   },
+  'id:49424D00': { // Same ID for IBM as above, except the "D" is capitalized as per TPM spec
+    name: 'IBM',
+    id: 'IBM',
+  },
   'id:49465800': {
     name: 'Infineon',
     id: 'IFX',


### PR DESCRIPTION
This PR adds an additional TPM manufacturer constant for IBM, capitalizing its ID as per the TPM spec.

Fixes #604.