### PR TITLE
fix/605-remove-uvm-dpk

### DIFF
--- a/packages/server/src/helpers/decodeAuthenticatorExtensions.ts
+++ b/packages/server/src/helpers/decodeAuthenticatorExtensions.ts
@@ -19,17 +19,10 @@ export function decodeAuthenticatorExtensions(
   return convertMapToObjectDeep(toCBOR);
 }
 
-export type AuthenticationExtensionsAuthenticatorOutputs = {
-  devicePubKey?: DevicePublicKeyAuthenticatorOutput;
-};
-
-export type DevicePublicKeyAuthenticatorOutput = {
-  dpk?: Uint8Array;
-  sig?: string;
-  nonce?: Uint8Array;
-  scope?: Uint8Array;
-  aaguid?: Uint8Array;
-};
+/**
+ * Attempt to support authenticator extensions we might not know about in WebAuthn
+ */
+export type AuthenticationExtensionsAuthenticatorOutputs = unknown;
 
 /**
  * CBOR-encoded extensions can be deeply-nested Maps, which are too deep for a simple

--- a/packages/server/src/helpers/decodeAuthenticatorExtensions.ts
+++ b/packages/server/src/helpers/decodeAuthenticatorExtensions.ts
@@ -21,7 +21,6 @@ export function decodeAuthenticatorExtensions(
 
 export type AuthenticationExtensionsAuthenticatorOutputs = {
   devicePubKey?: DevicePublicKeyAuthenticatorOutput;
-  uvm?: UVMAuthenticatorOutput;
 };
 
 export type DevicePublicKeyAuthenticatorOutput = {
@@ -30,12 +29,6 @@ export type DevicePublicKeyAuthenticatorOutput = {
   nonce?: Uint8Array;
   scope?: Uint8Array;
   aaguid?: Uint8Array;
-};
-
-// TODO: Need to verify this format
-// https://w3c.github.io/webauthn/#sctn-uvm-extension.
-export type UVMAuthenticatorOutput = {
-  uvm?: Uint8Array[];
 };
 
 /**


### PR DESCRIPTION
This PR removes support for the defunct `uvm` and `dpk` authenticator extensions.

Fixes #605.