### PR TITLE
fix/597-shadow-dom-support

### DIFF
--- a/packages/browser/src/methods/startAuthentication.test.ts
+++ b/packages/browser/src/methods/startAuthentication.test.ts
@@ -344,6 +344,32 @@ test('should throw error if no acceptable <input> is found', async () => {
   rejected.toThrow(/no <input>/i);
 });
 
+test('should not throw error when autofill input verification flag is false', async () => {
+  // No suitable <input> is present in the "light DOM", which would normally raise...
+  document.body.innerHTML = '<swan-autofill></swan-autofill>';
+
+  // ...But a suitable <input> IS inside of a web component's "shadow DOM" and we know it
+  const swanAutofill = document.querySelector('swan-autofill');
+  const shadowRoot = swanAutofill!.attachShadow({ mode: 'open' });
+  shadowRoot.innerHTML = `
+    <label for="username">Username</label>
+    <input
+      type="text"
+      name="username"
+      autocomplete="username webauthn"
+      autofocus
+    />
+  `;
+
+  await expect(
+    startAuthentication({
+      optionsJSON: goodOpts1,
+      useBrowserAutofill: true,
+      verifyBrowserAutofillInput: false,
+    }),
+  ).resolves;
+});
+
 test('should throw error if "webauthn" is not final autocomplete token', async () => {
   /**
    * According to WHATWG "webauthn" must be the final token in the autocomplete attribute when

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -13,6 +13,11 @@ import { identifyAuthenticationError } from '../helpers/identifyAuthenticationEr
 import { WebAuthnAbortService } from '../helpers/webAuthnAbortService';
 import { toAuthenticatorAttachment } from '../helpers/toAuthenticatorAttachment';
 
+export type StartAuthenticationOpts = {
+  optionsJSON: PublicKeyCredentialRequestOptionsJSON;
+  useBrowserAutofill?: boolean;
+};
+
 /**
  * Begin authenticator "login" via WebAuthn assertion
  *
@@ -20,9 +25,13 @@ import { toAuthenticatorAttachment } from '../helpers/toAuthenticatorAttachment'
  * @param useBrowserAutofill (Optional) Initialize conditional UI to enable logging in via browser autofill prompts. Defaults to `false`.
  */
 export async function startAuthentication(
-  optionsJSON: PublicKeyCredentialRequestOptionsJSON,
-  useBrowserAutofill = false,
+  options: StartAuthenticationOpts,
 ): Promise<AuthenticationResponseJSON> {
+  const {
+    optionsJSON,
+    useBrowserAutofill = false,
+  } = options;
+
   if (!browserSupportsWebAuthn()) {
     throw new Error('WebAuthn is not supported in this browser');
   }
@@ -44,7 +53,7 @@ export async function startAuthentication(
   };
 
   // Prepare options for `.get()`
-  const options: CredentialRequestOptions = {};
+  const getOptions: CredentialRequestOptions = {};
 
   /**
    * Set up the page to prompt the user to select a credential for authentication via the browser's
@@ -69,22 +78,22 @@ export async function startAuthentication(
 
     // `CredentialMediationRequirement` doesn't know about "conditional" yet as of
     // typescript@4.6.3
-    options.mediation = 'conditional' as CredentialMediationRequirement;
+    getOptions.mediation = 'conditional' as CredentialMediationRequirement;
     // Conditional UI requires an empty allow list
     publicKey.allowCredentials = [];
   }
 
   // Finalize options
-  options.publicKey = publicKey;
+  getOptions.publicKey = publicKey;
   // Set up the ability to cancel this request if the user attempts another
-  options.signal = WebAuthnAbortService.createNewAbortSignal();
+  getOptions.signal = WebAuthnAbortService.createNewAbortSignal();
 
   // Wait for the user to complete assertion
   let credential;
   try {
-    credential = (await navigator.credentials.get(options)) as AuthenticationCredential;
+    credential = (await navigator.credentials.get(getOptions)) as AuthenticationCredential;
   } catch (err) {
-    throw identifyAuthenticationError({ error: err as Error, options });
+    throw identifyAuthenticationError({ error: err as Error, options: getOptions });
   }
 
   if (!credential) {

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -16,6 +16,7 @@ import { toAuthenticatorAttachment } from '../helpers/toAuthenticatorAttachment'
 export type StartAuthenticationOpts = {
   optionsJSON: PublicKeyCredentialRequestOptionsJSON;
   useBrowserAutofill?: boolean;
+  verifyBrowserAutofillInput?: boolean;
 };
 
 /**
@@ -23,6 +24,7 @@ export type StartAuthenticationOpts = {
  *
  * @param optionsJSON Output from **@simplewebauthn/server**'s `generateAuthenticationOptions()`
  * @param useBrowserAutofill (Optional) Initialize conditional UI to enable logging in via browser autofill prompts. Defaults to `false`.
+ * @param verifyBrowserAutofillInput (Optional) Ensure a suitable `<input>` element is present when `useBrowserAutofill` is `true`. Defaults to `true`.
  */
 export async function startAuthentication(
   options: StartAuthenticationOpts,
@@ -30,6 +32,7 @@ export async function startAuthentication(
   const {
     optionsJSON,
     useBrowserAutofill = false,
+    verifyBrowserAutofillInput = true,
   } = options;
 
   if (!browserSupportsWebAuthn()) {
@@ -70,7 +73,7 @@ export async function startAuthentication(
     );
 
     // WebAuthn autofill requires at least one valid input
-    if (eligibleInputs.length < 1) {
+    if (eligibleInputs.length < 1 && verifyBrowserAutofillInput) {
       throw Error(
         'No <input> with "webauthn" as the only or last value in its `autocomplete` attribute was detected',
       );

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -68,7 +68,7 @@ afterEach(() => {
 });
 
 test('should convert options before passing to navigator.credentials.create(...)', async () => {
-  await startRegistration(goodOpts1);
+  await startRegistration({ optionsJSON: goodOpts1 });
 
   const argsPublicKey = mockNavigatorCreate.mock.calls[0][0].publicKey;
   const credId = argsPublicKey.excludeCredentials[0].id;
@@ -111,7 +111,7 @@ test('should return base64url-encoded response values', async () => {
     },
   );
 
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.rawId).toEqual('6mUg8GzxDxs');
   expect(response.response.attestationObject).toEqual('bW9ja0F0dGU');
@@ -121,7 +121,7 @@ test('should return base64url-encoded response values', async () => {
 test("should throw error if WebAuthn isn't supported", async () => {
   mockSupportsWebauthn.mockReturnValue(false);
 
-  await expect(startRegistration(goodOpts1)).rejects.toThrow(
+  await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects.toThrow(
     'WebAuthn is not supported in this browser',
   );
 });
@@ -133,7 +133,7 @@ test('should throw error if attestation is cancelled for some reason', async () 
     });
   });
 
-  await expect(startRegistration(goodOpts1)).rejects.toThrow(
+  await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects.toThrow(
     'Registration was not completed',
   );
 });
@@ -151,7 +151,7 @@ test('should send extensions to authenticator if present in options', async () =
     ...goodOpts1,
     extensions,
   };
-  await startRegistration(optsWithExts);
+  await startRegistration({ optionsJSON: optsWithExts });
 
   const argsExtensions = mockNavigatorCreate.mock.calls[0][0].publicKey.extensions;
 
@@ -159,7 +159,7 @@ test('should send extensions to authenticator if present in options', async () =
 });
 
 test('should not set any extensions if not present in options', async () => {
-  await startRegistration(goodOpts1);
+  await startRegistration({ optionsJSON: goodOpts1 });
 
   const argsExtensions = mockNavigatorCreate.mock.calls[0][0].publicKey.extensions;
 
@@ -182,13 +182,13 @@ test('should include extension results', async () => {
   });
 
   // Extensions aren't present in this object, but it doesn't matter since we're faking the response
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.clientExtensionResults).toEqual(extResults);
 });
 
 test('should include extension results when no extensions specified', async () => {
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.clientExtensionResults).toEqual({});
 });
@@ -204,7 +204,7 @@ test('should support "cable" transport in excludeCredentials', async () => {
     ],
   };
 
-  await startRegistration(opts);
+  await startRegistration({ optionsJSON: opts });
 
   expect(
     mockNavigatorCreate.mock.calls[0][0].publicKey.excludeCredentials[0]
@@ -225,7 +225,7 @@ test('should return "cable" transport from response', async () => {
     type: 'webauthn.create',
   });
 
-  const regResponse = await startRegistration(goodOpts1);
+  const regResponse = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(regResponse.response.transports).toEqual(['cable']);
 });
@@ -234,8 +234,8 @@ test('should cancel an existing call when executed again', async () => {
   const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
 
   // Fire off a request and immediately attempt a second one
-  startRegistration(goodOpts1);
-  await startRegistration(goodOpts1);
+  startRegistration({ optionsJSON: goodOpts1 });
+  await startRegistration({ optionsJSON: goodOpts1 });
   expect(abortSpy).toHaveBeenCalledTimes(1);
 });
 
@@ -251,7 +251,7 @@ test('should return authenticatorAttachment if present', async () => {
     });
   });
 
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.authenticatorAttachment).toEqual('cross-platform');
 });
@@ -276,7 +276,7 @@ test('should return convenience values if getters present', async () => {
     });
   });
 
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.response.publicKeyAlgorithm).toEqual(777);
   expect(response.response.publicKey).toEqual('AAAAAA');
@@ -299,7 +299,7 @@ test('should not return convenience values if getters missing', async () => {
     });
   });
 
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.response.publicKeyAlgorithm).toBeUndefined();
   expect(response.response.publicKey).toBeUndefined();
@@ -352,9 +352,9 @@ test('should survive browser extensions that intercept WebAuthn and incorrectly 
     });
   });
 
-  await expect(startRegistration(goodOpts1)).resolves;
+  await expect(startRegistration({ optionsJSON: goodOpts1 })).resolves;
 
-  const response = await startRegistration(goodOpts1);
+  const response = await startRegistration({ optionsJSON: goodOpts1 });
 
   expect(response.response.publicKeyAlgorithm).toBeUndefined();
   expect(response.response.publicKey).toBeUndefined();
@@ -374,7 +374,7 @@ describe('WebAuthnError', () => {
     test.skip('should identify abort signal', async () => {
       mockNavigatorCreate.mockRejectedValueOnce(AbortError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/abort signal/i);
       rejected.toThrow(/AbortError/);
@@ -397,7 +397,7 @@ describe('WebAuthnError', () => {
         },
       };
 
-      const rejected = await expect(startRegistration(opts)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: opts })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/discoverable credentials were required/i);
       rejected.toThrow(/no available authenticator supported/i);
@@ -419,7 +419,7 @@ describe('WebAuthnError', () => {
         },
       };
 
-      const rejected = await expect(startRegistration(opts)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: opts })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/user verification was required/i);
       rejected.toThrow(/no available authenticator supported/i);
@@ -438,7 +438,7 @@ describe('WebAuthnError', () => {
     test('should identify re-registration attempt', async () => {
       mockNavigatorCreate.mockRejectedValueOnce(InvalidStateError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/authenticator/i);
       rejected.toThrow(/previously registered/i);
@@ -465,7 +465,7 @@ describe('WebAuthnError', () => {
       );
       mockNavigatorCreate.mockRejectedValueOnce(NotAllowedError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrow(Error);
       rejected.toThrow(/operation failed/i);
       rejected.toHaveProperty('name', 'NotAllowedError');
@@ -486,7 +486,7 @@ describe('WebAuthnError', () => {
       );
       mockNavigatorCreate.mockRejectedValueOnce(NotAllowedError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrow(Error);
       rejected.toThrow(/sites with TLS certificate errors/i);
       rejected.toHaveProperty('name', 'NotAllowedError');
@@ -506,7 +506,7 @@ describe('WebAuthnError', () => {
         pubKeyCredParams: [],
       };
 
-      const rejected = await expect(startRegistration(opts)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: opts })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/pubKeyCredParams/i);
       rejected.toThrow(/public-key/i);
@@ -523,7 +523,7 @@ describe('WebAuthnError', () => {
         pubKeyCredParams: [{ alg: -7, type: 'public-key' }],
       };
 
-      const rejected = await expect(startRegistration(opts)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: opts })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/No available authenticator/i);
       rejected.toThrow(/pubKeyCredParams/i);
@@ -554,7 +554,7 @@ describe('WebAuthnError', () => {
 
       mockNavigatorCreate.mockRejectedValueOnce(SecurityError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrowError(WebAuthnError);
       rejected.toThrow(/1\.2\.3\.4/);
       rejected.toThrow(/invalid domain/i);
@@ -568,7 +568,7 @@ describe('WebAuthnError', () => {
 
       mockNavigatorCreate.mockRejectedValueOnce(SecurityError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrowError(WebAuthnError);
       rejected.toThrow(goodOpts1.rp.id);
       rejected.toThrow(/invalid for this domain/i);
@@ -592,7 +592,7 @@ describe('WebAuthnError', () => {
         },
       };
 
-      const rejected = await expect(startRegistration(opts)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: opts })).rejects;
       rejected.toThrowError(WebAuthnError);
       rejected.toThrow(/user id/i);
       rejected.toThrow(/not between 1 and 64 characters/i);
@@ -608,7 +608,7 @@ describe('WebAuthnError', () => {
     test('should identify potential authenticator issues', async () => {
       mockNavigatorCreate.mockRejectedValueOnce(UnknownError);
 
-      const rejected = await expect(startRegistration(goodOpts1)).rejects;
+      const rejected = await expect(startRegistration({ optionsJSON: goodOpts1 })).rejects;
       rejected.toThrow(WebAuthnError);
       rejected.toThrow(/authenticator/i);
       rejected.toThrow(/unable to process the specified options/i);


### PR DESCRIPTION
This PR adds a new `verifyBrowserAutofillInput` options to @simplewebauthn/browser's `startAuthentication()`. When set to `false` the method will no longer raise an error when it cannot find a suitable `<input autocomplete="... webauthn">` element.

Most users of this method shouldn't need to use this new flag. However projects using e.g. shadow components which contain an otherwise suitable element for conditional UI can use this new flag to benefit from `startAuthentication()` as well.

Fixes #597.

## Breaking Changes

### `startAuthentication()` now uses an option object

Positional arguments have been replaced by a single object containing all options. Keywords match the name of the previously positional arguments.

To update existing implementations, wrap existing options in an object with corresponding properties:

**Before:**

```ts
startAuthentication(options, true);
```

**After:**

```ts
startAuthentication({ optionsJSON: options, useBrowserAutofill: true });
```

### `startRegistration()` now uses an option object

Positional arguments have been replaced by a single object containing all options. Keywords match the name of the previously positional arguments.

To update existing implementations, wrap existing options in an object with corresponding properties:

**Before:**

```ts
startRegistration(options);
```

**After:**

```ts
startRegistration({ optionsJSON: options });
```

(It may seem premature to make this change to `startRegistration()` too, but this is in preparation for #582)