### PR TITLE
Also test Node 22, and Deno v1.46 and Deno v2.0

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 20, 22 ]
-        deno-version: [ 'v1.41.0', 'v1.46.3' ]
+        deno-version: [ 'v1.46.x', 'v2.0.x' ]
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
 
     # Install Deno
     - name: Setup Deno ${{ matrix.deno-version }}
-      uses: denoland/setup-deno@v1
+      uses: denoland/setup-deno@v2
       with:
         deno-version: ${{ matrix.deno-version }}
     - name: Confirm installed Deno version

--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 20 ]
-        deno-version: [ 'v1.41.0' ]
+        node-version: [ 20, 22 ]
+        deno-version: [ 'v1.41.0', 'v1.46.3' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -20,7 +20,7 @@ jobs:
         deno-version: [ 'v1.46.x', 'v2.0.x' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Install Node
     - name: Setup Node.js ${{ matrix.node-version }}
@@ -41,7 +41,7 @@ jobs:
     # Install pnpm w/cache for quicker installs
     # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time
     - name: Setup pnpm 9.12.3
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: 9.12.3
         run_install: false
@@ -50,7 +50,7 @@ jobs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
     - name: Setup pnpm cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ request new features, or to suggest changes to existing features.
 Install the following before proceeding:
 
 - **Node 20.x**
-- **Deno 1.41.x**
+- **Deno v1.46.x**
 - **pnpm 9.12.x**
 
 After pulling down the code, set up dependencies:


### PR DESCRIPTION
Node 22 went LTS at the end of October so it's time to add it to the testing matrix. I'm also contemplating testing the latest Deno v1 release, before testing the latest v1 and including v2 in the testing matrix.