### PR TITLE
feat/reg-hints

### DIFF
--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -42,6 +42,8 @@ const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
       transports: ['internal'],
     },
   ],
+  hints: ['client-device', 'hybrid', 'security-key'],
+  attestationFormats: ['packed'],
 };
 
 /**
@@ -93,6 +95,12 @@ describe('Method: startRegistration', () => {
     assertEquals(credId.byteLength, 64);
     assertEquals(argsPublicKey.excludeCredentials?.[0].type, 'public-key');
     assertEquals(argsPublicKey.excludeCredentials?.[0].transports, ['internal']);
+
+    // Confirm hints and attestationFormats
+    // @ts-ignore: we know `hints` are becoming available in browsers
+    assertEquals(argsPublicKey.hints, ['client-device', 'hybrid', 'security-key']);
+    // @ts-ignore: we know `attestationFormats` are becoming available in browsers
+    assertEquals(argsPublicKey.attestationFormats, ['packed']);
   });
 
   it('should return base64url-encoded response values', async () => {

--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -8,6 +8,8 @@ import type {
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
 import { generateChallenge } from '../helpers/generateChallenge.ts';
 
+export type GenerateAuthenticationOptionsOpts = Parameters<typeof generateAuthenticationOptions>[0];
+
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator authentication
  *

--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -3,23 +3,10 @@ import type {
   AuthenticatorTransportFuture,
   Base64URLString,
   PublicKeyCredentialRequestOptionsJSON,
-  UserVerificationRequirement,
 } from '@simplewebauthn/types';
 
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
 import { generateChallenge } from '../helpers/generateChallenge.ts';
-
-export type GenerateAuthenticationOptionsOpts = {
-  rpID: string;
-  allowCredentials?: {
-    id: Base64URLString;
-    transports?: AuthenticatorTransportFuture[];
-  }[];
-  challenge?: string | Uint8Array;
-  timeout?: number;
-  userVerification?: UserVerificationRequirement;
-  extensions?: AuthenticationExtensionsClientInputs;
-};
 
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator authentication
@@ -34,7 +21,17 @@ export type GenerateAuthenticationOptionsOpts = {
  * @param extensions **(Optional)** - Additional plugins the authenticator or browser should use during authentication
  */
 export async function generateAuthenticationOptions(
-  options: GenerateAuthenticationOptionsOpts,
+  options: {
+    rpID: string;
+    allowCredentials?: {
+      id: Base64URLString;
+      transports?: AuthenticatorTransportFuture[];
+    }[];
+    challenge?: string | Uint8Array;
+    timeout?: number;
+    userVerification?: 'required' | 'preferred' | 'discouraged';
+    extensions?: AuthenticationExtensionsClientInputs;
+  },
 ): Promise<PublicKeyCredentialRequestOptionsJSON> {
   const {
     allowCredentials,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,8 @@ export {
   verifyRegistrationResponse,
 };
 
+import type { GenerateRegistrationOptionsOpts } from './registration/generateRegistrationOptions.ts';
+import type { GenerateAuthenticationOptionsOpts } from './authentication/generateAuthenticationOptions.ts';
 import type { MetadataStatement } from './metadata/mdsTypes.ts';
 import type {
   VerifiedRegistrationResponse,
@@ -29,6 +31,8 @@ import type {
 } from './authentication/verifyAuthenticationResponse.ts';
 
 export type {
+  GenerateAuthenticationOptionsOpts,
+  GenerateRegistrationOptionsOpts,
   MetadataStatement,
   VerifiedAuthenticationResponse,
   VerifiedRegistrationResponse,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,8 +18,6 @@ export {
   verifyRegistrationResponse,
 };
 
-import type { GenerateRegistrationOptionsOpts } from './registration/generateRegistrationOptions.ts';
-import type { GenerateAuthenticationOptionsOpts } from './authentication/generateAuthenticationOptions.ts';
 import type { MetadataStatement } from './metadata/mdsTypes.ts';
 import type {
   VerifiedRegistrationResponse,
@@ -31,8 +29,6 @@ import type {
 } from './authentication/verifyAuthenticationResponse.ts';
 
 export type {
-  GenerateAuthenticationOptionsOpts,
-  GenerateRegistrationOptionsOpts,
   MetadataStatement,
   VerifiedAuthenticationResponse,
   VerifiedRegistrationResponse,

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -12,7 +12,7 @@ Deno.test('should generate credential request options suitable for sending via J
   const userID = isoUint8Array.fromUTF8String('1234');
   const userName = 'usernameHere';
   const timeout = 1;
-  const attestationType = 'indirect';
+  const attestationType = 'direct';
   const userDisplayName = 'userDisplayName';
 
   const options = await generateRegistrationOptions({

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -56,6 +56,7 @@ Deno.test('should generate credential request options suitable for sending via J
       extensions: {
         credProps: true,
       },
+      hints: [],
     },
   );
 });
@@ -333,4 +334,55 @@ Deno.test('should raise if string is specified for userID', async () => {
     Error,
     'String values for `userID` are no longer supported. See https://simplewebauthn.dev/docs/advanced/server/custom-user-ids',
   );
+});
+
+Deno.test('should map undefined authenticator preference to empty hint', async () => {
+  const options = await generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userName: 'usernameHere',
+    preferredAuthenticatorType: undefined,
+  });
+
+  assertEquals(options.hints, []);
+});
+
+Deno.test('should map "securityKey" authenticator preference to hint and attachment', async () => {
+  const options = await generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userName: 'usernameHere',
+    preferredAuthenticatorType: 'securityKey',
+  });
+
+  assertEquals(options.hints, ['security-key']);
+  assertEquals(options.authenticatorSelection?.authenticatorAttachment, 'cross-platform');
+});
+
+Deno.test('should map "localDevice" authenticator preference to hint and attachment', async () => {
+  const options = await generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userName: 'usernameHere',
+    preferredAuthenticatorType: 'localDevice',
+  });
+
+  assertEquals(options.hints, ['client-device']);
+  assertEquals(options.authenticatorSelection?.authenticatorAttachment, 'platform');
+});
+
+Deno.test('should map "remoteDevice" authenticator preference to hint and attachment', async () => {
+  const options = await generateRegistrationOptions({
+    rpName: 'SimpleWebAuthn',
+    rpID: 'not.real',
+    challenge: 'totallyrandomvalue',
+    userName: 'usernameHere',
+    preferredAuthenticatorType: 'remoteDevice',
+  });
+
+  assertEquals(options.hints, ['hybrid']);
+  assertEquals(options.authenticatorSelection?.authenticatorAttachment, 'cross-platform');
 });

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -13,6 +13,8 @@ import { generateChallenge } from '../helpers/generateChallenge.ts';
 import { generateUserID } from '../helpers/generateUserID.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
 
+export type GenerateRegistrationOptionsOpts = Parameters<typeof generateRegistrationOptions>[0];
+
 /**
  * Supported crypto algo identifiers
  * See https://w3c.github.io/webauthn/#sctn-alg-identifier

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -1,5 +1,4 @@
 import type {
-  AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticatorSelectionCriteria,
   AuthenticatorTransportFuture,
@@ -12,24 +11,6 @@ import type {
 import { generateChallenge } from '../helpers/generateChallenge.ts';
 import { generateUserID } from '../helpers/generateUserID.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
-
-export type GenerateRegistrationOptionsOpts = {
-  rpName: string;
-  rpID: string;
-  userName: string;
-  userID?: Uint8Array;
-  challenge?: string | Uint8Array;
-  userDisplayName?: string;
-  timeout?: number;
-  attestationType?: AttestationConveyancePreference;
-  excludeCredentials?: {
-    id: Base64URLString;
-    transports?: AuthenticatorTransportFuture[];
-  }[];
-  authenticatorSelection?: AuthenticatorSelectionCriteria;
-  extensions?: AuthenticationExtensionsClientInputs;
-  supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
-};
 
 /**
  * Supported crypto algo identifiers
@@ -98,7 +79,23 @@ const defaultSupportedAlgorithmIDs: COSEAlgorithmIdentifier[] = [-8, -7, -257];
  * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers supported for attestation by this RP. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]`
  */
 export async function generateRegistrationOptions(
-  options: GenerateRegistrationOptionsOpts,
+  options: {
+    rpName: string;
+    rpID: string;
+    userName: string;
+    userID?: Uint8Array;
+    challenge?: string | Uint8Array;
+    userDisplayName?: string;
+    timeout?: number;
+    attestationType?: 'direct' | 'enterprise' | 'none';
+    excludeCredentials?: {
+      id: Base64URLString;
+      transports?: AuthenticatorTransportFuture[];
+    }[];
+    authenticatorSelection?: AuthenticatorSelectionCriteria;
+    extensions?: AuthenticationExtensionsClientInputs;
+    supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
+  },
 ): Promise<PublicKeyCredentialCreationOptionsJSON> {
   const {
     rpName,


### PR DESCRIPTION
This PR adds support for registration-time WebAuthn hints as the new `preferredAuthenticatorType` argument in `generateRegistrationOptions()`. The following values are supported:

- `'securityKey'`
- `'localDevice'`
- `'remoteDevice'`

Each maps to the following combinations of `PublicKeyCredentialHint` (and `AuthenticatorAttachment` for backwards compatibility) in registration options:

- `'securityKey'` ➡️ `['security-key']` / `'cross-platform'`
- `'localDevice'` ➡️ `['client-device']` / `'platform'`
- `'remoteDevice'` ➡️ `['hybrid']` / `'cross-platform'`

WebAuthn hints [do allow for multiple values and sorting by "decreasing preference"](https://w3c.github.io/webauthn/#enum-hints). However I am taking the position here (after taking the same position when we drafted hints into the WebAuthn spec) that the greatest utility of hints comes from being able to fine-tune WebAuthn registration from two ceremonies ("platform, or security key/hybrid") into three ceremonies ("platform, security key, or hybrid".) This means only specifying one hint per ceremony **for those RP's that wish for the greater degree of nuance when initiating passkey registration.**