### PR TITLE
fix/658-remove-cross-fetch-from-server

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -41,7 +41,6 @@
     "npm:@rollup/plugin-node-resolve@^15.3.0": "15.3.0_rollup@4.27.3",
     "npm:@rollup/plugin-replace@^6.0.1": "6.0.1_rollup@4.27.3",
     "npm:@rollup/plugin-terser@~0.4.4": "0.4.4_rollup@4.27.3",
-    "npm:cross-fetch@4": "4.0.0",
     "npm:jsdom@^25.0.1": "25.0.1",
     "npm:rollup-plugin-version-injector@^1.3.3": "1.3.3",
     "npm:rollup@^4.27.3": "4.27.3",
@@ -1259,12 +1258,6 @@
         "browserslist"
       ]
     },
-    "cross-fetch@4.0.0": {
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": [
-        "node-fetch"
-      ]
-    },
     "cssstyle@4.1.0": {
       "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
       "dependencies": [
@@ -1275,7 +1268,7 @@
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": [
         "whatwg-mimetype",
-        "whatwg-url@14.0.0"
+        "whatwg-url"
       ]
     },
     "dateformat@4.6.3": {
@@ -1408,10 +1401,10 @@
         "symbol-tree",
         "tough-cookie",
         "w3c-xmlserializer",
-        "webidl-conversions@7.0.0",
+        "webidl-conversions",
         "whatwg-encoding",
         "whatwg-mimetype",
-        "whatwg-url@14.0.0",
+        "whatwg-url",
         "ws",
         "xml-name-validator"
       ]
@@ -1457,12 +1450,6 @@
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node-fetch@2.7.0": {
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": [
-        "whatwg-url@5.0.0"
-      ]
     },
     "node-releases@2.0.18": {
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
@@ -1665,9 +1652,6 @@
         "tldts"
       ]
     },
-    "tr46@0.0.3": {
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "tr46@5.0.0": {
       "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dependencies": [
@@ -1717,9 +1701,6 @@
         "xml-name-validator"
       ]
     },
-    "webidl-conversions@3.0.1": {
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
     "webidl-conversions@7.0.0": {
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
     },
@@ -1735,15 +1716,8 @@
     "whatwg-url@14.0.0": {
       "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dependencies": [
-        "tr46@5.0.0",
-        "webidl-conversions@7.0.0"
-      ]
-    },
-    "whatwg-url@5.0.0": {
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": [
-        "tr46@0.0.3",
-        "webidl-conversions@3.0.1"
+        "tr46",
+        "webidl-conversions"
       ]
     },
     "ws@8.18.0": {
@@ -1786,8 +1760,7 @@
           "npm:@peculiar/asn1-ecc@^2.3.8",
           "npm:@peculiar/asn1-rsa@^2.3.8",
           "npm:@peculiar/asn1-schema@^2.3.8",
-          "npm:@peculiar/asn1-x509@^2.3.8",
-          "npm:cross-fetch@4"
+          "npm:@peculiar/asn1-x509@^2.3.8"
         ]
       }
     }

--- a/packages/server/deno.json
+++ b/packages/server/deno.json
@@ -43,8 +43,7 @@
     "@peculiar/asn1-ecc": "npm:@peculiar/asn1-ecc@^2.3.8",
     "@peculiar/asn1-rsa": "npm:@peculiar/asn1-rsa@^2.3.8",
     "@peculiar/asn1-schema": "npm:@peculiar/asn1-schema@^2.3.8",
-    "@peculiar/asn1-x509": "npm:@peculiar/asn1-x509@^2.3.8",
-    "cross-fetch": "npm:cross-fetch@^4.0.0"
+    "@peculiar/asn1-x509": "npm:@peculiar/asn1-x509@^2.3.8"
   },
   "publish": {
     "include": [

--- a/packages/server/src/helpers/fetch.ts
+++ b/packages/server/src/helpers/fetch.ts
@@ -1,5 +1,3 @@
-import { fetch as crossFetch } from 'cross-fetch';
-
 /**
  * A simple method for requesting data via standard `fetch`. Should work
  * across multiple runtimes.
@@ -13,5 +11,5 @@ export function fetch(url: string): Promise<Response> {
  * @ignore Don't include this in docs output
  */
 export const _fetchInternals = {
-  stubThis: (url: string) => crossFetch(url),
+  stubThis: (url: string) => globalThis.fetch(url),
 };


### PR DESCRIPTION
This PR removes the `cross-fetch` dependency from **@simplewebauthn/server** as it's no longer needed thanks to the project targeting Node 20+.

I'm keeping the `fetch()` helper around to make it easier to mock responses during testing.

Fixes #658.