### PR TITLE
fix/browser-tolerate-old-call-structures

### DIFF
--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -28,6 +28,16 @@ export async function startAuthentication(
     verifyBrowserAutofillInput?: boolean;
   },
 ): Promise<AuthenticationResponseJSON> {
+  // @ts-ignore: Intentionally check for old call structure to warn about improper API call
+  if (!options.optionsJSON && options.challenge) {
+    console.warn(
+      'startAuthentication() was not called correctly. It will try to continue with the provided options, but this call should be refactored to use the expected call structure instead. See https://simplewebauthn.dev/docs/packages/browser#typeerror-cannot-read-properties-of-undefined-reading-challenge for more information.',
+    );
+
+    // @ts-ignore: Reassign the options, passed in as a positional argument, to the expected variable
+    options = { optionsJSON: options };
+  }
+
   const {
     optionsJSON,
     useBrowserAutofill = false,

--- a/packages/browser/src/methods/startRegistration.test.ts
+++ b/packages/browser/src/methods/startRegistration.test.ts
@@ -374,6 +374,31 @@ describe('Method: startRegistration', () => {
     // The most important bit
     assertEquals(argsMediation, 'conditional');
   });
+
+  it('should continue despite use of old call structure', async () => {
+    const stubConsoleWarn = stub(console, 'warn');
+
+    // @ts-ignore: Intentionally call this method in a pre-v11 way
+    await startRegistration(goodOpts1);
+
+    assertSpyCalls(stubConsoleWarn, 1);
+
+    // Assert there's some browser console output
+    const warning = stubConsoleWarn.calls.at(0)?.args[0] as string;
+    assertStringIncludes(warning, 'startRegistration() was not called correctly');
+
+    // Check that the method was able to handle the bad call anyway
+    const args = createSpy.calls.at(0)?.args[0] as CredentialCreationOptions;
+    const argsPublicKey = args.publicKey!;
+
+    // Make sure challenge and user.id are converted to Buffers
+    assertEquals(
+      new Uint8Array(argsPublicKey.challenge as ArrayBuffer),
+      new Uint8Array([213, 62, 174, 30, 184, 184, 56, 4]),
+    );
+
+    stubConsoleWarn.restore();
+  });
 });
 
 describe('WebAuthnError', () => {

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -26,6 +26,16 @@ export async function startRegistration(
     useAutoRegister?: boolean;
   },
 ): Promise<RegistrationResponseJSON> {
+  // @ts-ignore: Intentionally check for old call structure to warn about improper API call
+  if (!options.optionsJSON && options.challenge) {
+    console.warn(
+      'startRegistration() was not called correctly. It will try to continue with the provided options, but this call should be refactored to use the expected call structure instead. See https://simplewebauthn.dev/docs/packages/browser#typeerror-cannot-read-properties-of-undefined-reading-challenge for more information.',
+    );
+
+    // @ts-ignore: Reassign the options, passed in as a positional argument, to the expected variable
+    options = { optionsJSON: options };
+  }
+
   const { optionsJSON, useAutoRegister = false } = options;
 
   if (!browserSupportsWebAuthn()) {


### PR DESCRIPTION
I've prepared a PR that updates **@simplewebauthn/browser**'s `startRegistration()` and `startAuthentication()` to detect and tolerate the old, pre-v11 method call (where options are passed in as a positional argument as instead of as the `optionsJSON` property in the options blob.) There's a lot of existing developer guidance on using SimpleWebAuthn that reflects the pre-v11 method call structure, and rather than hope it all gets updated I figured for sake of developer DX a PR like this would engender some developer goodwill. 

With this PR these methods would `console.warn` in the browser console about needing to update the method call, but ultimately try to proceed by internally remapping the provided options to `optionsJSON`. The warning would also direct devs to here for more info:

https://simplewebauthn.dev/docs/packages/browser#typeerror-cannot-read-properties-of-undefined-reading-challenge

## Screenshots

![Screenshot 2025-01-12 at 4 19 05 PM](https://github.com/user-attachments/assets/5961b75d-4331-484d-89bf-e856a67a8393)
