### PR TITLE
feat(Extensions): Add prf extension interfaces

### DIFF
--- a/packages/browser/src/types/dom.ts
+++ b/packages/browser/src/types/dom.ts
@@ -50,12 +50,24 @@ export interface AuthenticationExtensionsClientInputs {
     credProps?: boolean;
     hmacCreateSecret?: boolean;
     minPinLength?: boolean;
+    prf?: AuthenticationExtensionsPRFInputs;
 }
+export interface AuthenticationExtensionsPRFInputs {
+    eval?: AuthenticationExtensionsPRFValues;
+    evalByCredential?: Record<string, AuthenticationExtensionsPRFValues>;
+}
+
+export interface AuthenticationExtensionsPRFOutputs {
+    enabled?: boolean;
+    results?: AuthenticationExtensionsPRFValues;
+}
+
 
 export interface AuthenticationExtensionsClientOutputs {
     appid?: boolean;
     credProps?: CredentialPropertiesOutput;
     hmacCreateSecret?: boolean;
+    prf?: AuthenticationExtensionsPRFOutputs;
 }
 
 export interface AuthenticatorSelectionCriteria {

--- a/packages/browser/src/types/dom.ts
+++ b/packages/browser/src/types/dom.ts
@@ -62,7 +62,6 @@ export interface AuthenticationExtensionsPRFOutputs {
     results?: AuthenticationExtensionsPRFValues;
 }
 
-
 export interface AuthenticationExtensionsClientOutputs {
     appid?: boolean;
     credProps?: CredentialPropertiesOutput;

--- a/packages/browser/src/types/dom.ts
+++ b/packages/browser/src/types/dom.ts
@@ -57,6 +57,11 @@ export interface AuthenticationExtensionsPRFInputs {
     evalByCredential?: Record<string, AuthenticationExtensionsPRFValues>;
 }
 
+export interface AuthenticationExtensionsPRFValues {
+    first: BufferSource;
+    second?: BufferSource;
+}
+
 export interface AuthenticationExtensionsPRFOutputs {
     enabled?: boolean;
     results?: AuthenticationExtensionsPRFValues;


### PR DESCRIPTION
This pull request introduces new interfaces and properties to support the PRF (Pseudorandom Function) [extension](https://github.com/w3c/webauthn/wiki/Explainer:-PRF-extension) in WebAuthn authentication flows. It adds:
- `AuthenticationExtensionsPRFValues`
- `AuthenticationExtensionsPRFInputs`
- `AuthenticationExtensionsPRFOutputs`
- Updated `AuthenticationExtensionsClientInputs` and `AuthenticationExtensionsClientOutputs` with the prf inputs and outputs respectively.

How to use:
```ts
const pubKeyCredential: PublicKeyCredential = credential;
const clientExtensions = credential.getClientExtensionResults()
const isPrfEnabled = clientExtensions.prf?.enabled
const prfValue = new Uint8Array(extensions.prf.results?.first);
```

Once the prf value is obtained, a CryptoKey can be derived to be used in the browser to encrypt/decrypt data.  (https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/)

PRF Specification:
https://www.w3.org/TR/webauthn-3/#prf-extension