### PR TITLE
Update tests for the passage of time (May 2025)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
-  "deno.path": "/opt/homebrew/bin/deno",
+  "deno.path": "/Users/matt/.dvm/bin/deno",
   "deno.enable": true,
   "deno.config": "./deno.json",
   "deno.disablePaths": [

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
@@ -4,6 +4,13 @@ import { FakeTime } from '@std/testing/time';
 import { verifyRegistrationResponse } from '../../verifyRegistrationResponse.ts';
 
 Deno.test('should verify TPM response', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2018-02-01T00:00:00.000Z,
+  //   notAfter: 2025-01-31T23:59:59.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-01-30T23:59:59.000Z'));
+
   const verification = await verifyRegistrationResponse({
     response: {
       id: 'SErwRhxIzjPowcnM3e-D-u89EQXLUe1NYewpshd7Mc0',
@@ -25,9 +32,18 @@ Deno.test('should verify TPM response', async () => {
   });
 
   assertEquals(verification.verified, true);
+
+  mockDate.restore();
 });
 
 Deno.test('should verify SHA1 TPM response', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2018-02-01T00:00:00.000Z,
+  //   notAfter: 2025-01-31T23:59:59.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-01-30T23:59:59.000Z'));
+
   /**
    * Generated on real hardware on 03/03/2020
    *
@@ -55,9 +71,18 @@ Deno.test('should verify SHA1 TPM response', async () => {
   });
 
   assertEquals(verification.verified, true);
+
+  mockDate.restore();
 });
 
 Deno.test('should verify SHA256 TPM response', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2018-02-01T00:00:00.000Z,
+  //   notAfter: 2025-01-31T23:59:59.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-01-30T23:59:59.000Z'));
+
   /**
    * Generated on real hardware on 03/03/2020
    *
@@ -85,9 +110,17 @@ Deno.test('should verify SHA256 TPM response', async () => {
   });
 
   assertEquals(verification.verified, true);
+
+  mockDate.restore();
 });
 
 Deno.test('should verify TPM response with spec-compliant tcgAtTpm SAN structure', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2020-08-27T15:12:30.000Z,
+  //   notAfter: 2025-03-21T20:29:15.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-03-20T00:00:42.000Z'));
   /**
    * Name [
    *   RelativeDistinguishedName [
@@ -121,6 +154,8 @@ Deno.test('should verify TPM response with spec-compliant tcgAtTpm SAN structure
   });
 
   assertEquals(verification.verified, true);
+
+  mockDate.restore();
 });
 
 Deno.test('should verify TPM response with non-spec-compliant tcgAtTpm SAN structure', async () => {

--- a/packages/server/src/registration/verifications/verifyAttestationAndroidSafetyNet.test.ts
+++ b/packages/server/src/registration/verifications/verifyAttestationAndroidSafetyNet.test.ts
@@ -121,7 +121,7 @@ Deno.test('should throw error when timestamp is not within one minute of now', a
   );
 });
 
-Deno.test('should validate response with cert path completed with GlobalSign R1 root cert', async () => {
+Deno.test('should reject when a revoked certificate is found', async () => {
   const {
     aaguid,
     attStmt,
@@ -151,19 +151,22 @@ Deno.test('should validate response with cert path completed with GlobalSign R1 
   // }
   const mockDate = new FakeTime(new Date('2021-10-15T00:00:42.000Z'));
 
-  const verified = await verifyAttestationAndroidSafetyNet({
-    attStmt,
-    authData,
-    clientDataHash,
-    verifyTimestampMS: false,
-    aaguid,
-    rootCertificates,
-    credentialID,
-    credentialPublicKey,
-    rpIdHash,
-  });
-
-  assert(verified);
+  await assertRejects(
+    () =>
+      verifyAttestationAndroidSafetyNet({
+        attStmt,
+        authData,
+        clientDataHash,
+        verifyTimestampMS: false,
+        aaguid,
+        rootCertificates,
+        credentialID,
+        credentialPublicKey,
+        rpIdHash,
+      }),
+    Error,
+    'revoked certificate',
+  );
 
   mockDate.restore();
 });

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals, assertFalse, assertObjectMatch, assertRejects } from '@std/assert';
 import { returnsNext, stub } from '@std/testing/mock';
+import { FakeTime } from '@std/testing/time';
 
 import { verifyRegistrationResponse } from './verifyRegistrationResponse.ts';
 import type { RegistrationResponseJSON } from '../types/index.ts';
@@ -608,6 +609,13 @@ Deno.test(
 );
 
 Deno.test('should validate TPM RSA response (SHA256)', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2018-02-01T00:00:00.000Z,
+  //   notAfter: 2025-01-31T23:59:59.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-01-30T23:59:59.000Z'));
+
   const expectedChallenge = '3a07cf85-e7b6-447f-8270-b25433f6018e';
   const verification = await verifyRegistrationResponse({
     response: {
@@ -647,9 +655,18 @@ Deno.test('should validate TPM RSA response (SHA256)', async () => {
     'https://dev.dontneeda.pw',
   );
   assertEquals(verification.registrationInfo?.rpID, 'dev.dontneeda.pw');
+
+  mockDate.restore();
 });
 
 Deno.test('should validate TPM RSA response (SHA1)', async () => {
+  // Faking time to something that'll satisfy all of these ranges:
+  // {
+  //   notBefore: 2018-02-01T00:00:00.000Z,
+  //   notAfter: 2025-01-31T23:59:59.000Z
+  // }
+  const mockDate = new FakeTime(new Date('2025-01-30T23:59:59.000Z'));
+
   const expectedChallenge = 'f4e8d87b-d363-47cc-ab4d-1a84647bf245';
   const verification = await verifyRegistrationResponse({
     response: {
@@ -689,6 +706,8 @@ Deno.test('should validate TPM RSA response (SHA1)', async () => {
     'https://dev.dontneeda.pw',
   );
   assertEquals(verification.registrationInfo?.rpID, 'dev.dontneeda.pw');
+
+  mockDate.restore();
 });
 
 Deno.test('should validate Android-Key response', async () => {


### PR DESCRIPTION
Some test failures popped up as the future arrived, so I sprinkled in some more date mocking. It seems a root cert used to validate Android SafetyNet attestations was also revoked so I've updated those tests to be sad path tests instead.