### PR TITLE
fix(server): export missing required type

### DIFF
--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -46,6 +46,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -46,6 +46,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 


### PR DESCRIPTION
`ResidentKeyRequirement` is a dependency of `PublicKeyCredentialCreationOptionsJSON.AuthenticatorSelectionCriteria`. exporting it attempts to fix typescript "not portable" errors.

# reproduction case
index.js:
```ts
import {
  generateRegistrationOptions,
  type PublicKeyCredentialCreationOptionsJSON,
} from "@simplewebauthn/server";
import { Hono } from "hono";

export default new Hono().get("/", async (c) => {
  const options: PublicKeyCredentialCreationOptionsJSON =
    await generateRegistrationOptions({
      rpID: "test.com",
      rpName: "test",
      userName: "test",
    });
  return c.json(options, 200);
});
```

run:
```bash
tsc --declaration --skipLibCheck --module esnext --moduleResolution bundler index.ts
```

error:
```log
index.ts(7,1): error TS2742: The inferred type of 'default' cannot be named without a reference to './node_modules/@simplewebauthn/server/esm/types/dom'. This is likely not portable. A type annotation is necessary.
```