### PR TITLE
Export ResidentKeyRequirement type for better type inference

### DIFF
--- a/packages/browser/src/types/dom.ts
+++ b/packages/browser/src/types/dom.ts
@@ -359,9 +359,9 @@ export interface RsaKeyGenParams extends Algorithm {
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
 export type COSEAlgorithmIdentifier = number;
+export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";
 export type AuthenticatorAttachment = "cross-platform" | "platform";
-export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type BufferSource = ArrayBufferView | ArrayBuffer;
 export type PublicKeyCredentialType = "public-key";
 export type AlgorithmIdentifier = Algorithm | string;

--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -46,6 +46,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 

--- a/packages/server/src/types/dom.ts
+++ b/packages/server/src/types/dom.ts
@@ -359,9 +359,9 @@ export interface RsaKeyGenParams extends Algorithm {
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
 export type COSEAlgorithmIdentifier = number;
+export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";
 export type AuthenticatorAttachment = "cross-platform" | "platform";
-export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type BufferSource = ArrayBufferView | ArrayBuffer;
 export type PublicKeyCredentialType = "public-key";
 export type AlgorithmIdentifier = Algorithm | string;

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -46,6 +46,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 

--- a/packages/types/extract-dom-types.ts
+++ b/packages/types/extract-dom-types.ts
@@ -40,6 +40,7 @@ const types = [
   'PublicKeyCredentialParameters',
   'PublicKeyCredentialRequestOptions',
   'PublicKeyCredentialUserEntity',
+  'ResidentKeyRequirement',
   'UserVerificationRequirement',
 ];
 

--- a/packages/types/src/dom.ts
+++ b/packages/types/src/dom.ts
@@ -351,9 +351,9 @@ export interface RsaKeyGenParams extends Algorithm {
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
 export type COSEAlgorithmIdentifier = number;
+export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";
 export type AuthenticatorAttachment = "cross-platform" | "platform";
-export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type BufferSource = ArrayBufferView | ArrayBuffer;
 export type PublicKeyCredentialType = "public-key";
 export type AlgorithmIdentifier = Algorithm | string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,7 @@ export type {
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
   PublicKeyCredentialUserEntity,
+  ResidentKeyRequirement,
   UserVerificationRequirement,
 } from './dom.ts';
 


### PR DESCRIPTION
This PR adds an explicit export of the `ResidentKeyRequirement` type. According to #698 this should help support projects that try to infer types but fail because of this missing exported DOM type. 