### PR TITLE
Improve TypeScript type narrowing

### DIFF
--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -275,36 +275,39 @@ export async function verifyRegistrationResponse(
     throw new Error(`Unsupported Attestation Format: ${fmt}`);
   }
 
-  const toReturn: VerifiedRegistrationResponse = {
-    verified,
-  };
-
-  if (toReturn.verified) {
-    const { credentialDeviceType, credentialBackedUp } = parseBackupFlags(
-      flags,
-    );
-
-    toReturn.registrationInfo = {
-      fmt,
-      aaguid: convertAAGUIDToString(aaguid),
-      credentialType,
-      credential: {
-        id: isoBase64URL.fromBuffer(credentialID),
-        publicKey: credentialPublicKey,
-        counter,
-        transports: response.response.transports,
-      },
-      attestationObject,
-      userVerified: flags.uv,
-      credentialDeviceType,
-      credentialBackedUp,
-      origin: clientDataJSON.origin,
-      rpID: matchedRPID,
-      authenticatorExtensionResults: extensionsData,
+  if (!verified) {
+    return {
+      verified,
     };
   }
 
-  return toReturn;
+  const { credentialDeviceType, credentialBackedUp } = parseBackupFlags(
+    flags,
+  );
+
+  const registrationInfo = {
+    fmt,
+    aaguid: convertAAGUIDToString(aaguid),
+    credentialType,
+    credential: {
+      id: isoBase64URL.fromBuffer(credentialID),
+      publicKey: credentialPublicKey,
+      counter,
+      transports: response.response.transports,
+    },
+    attestationObject,
+    userVerified: flags.uv,
+    credentialDeviceType,
+    credentialBackedUp,
+    origin: clientDataJSON.origin,
+    rpID: matchedRPID,
+    authenticatorExtensionResults: extensionsData,
+  };
+
+  return {
+    verified,
+    registrationInfo,
+  };
 }
 
 /**
@@ -333,9 +336,9 @@ export async function verifyRegistrationResponse(
  * @param registrationInfo?.authenticatorExtensionResults The authenticator extensions returned
  * by the browser
  */
-export type VerifiedRegistrationResponse = {
-  verified: boolean;
-  registrationInfo?: {
+export type VerifiedRegistrationResponse = { verified: false; registrationInfo?: never } | {
+  verified: true;
+  registrationInfo: {
     fmt: AttestationFormat;
     aaguid: string;
     credential: WebAuthnCredential;


### PR DESCRIPTION
Hi, thanks for providing this library. I ran across a TypeScript issue with the type `VerifiedRegistrationResponse` where Typescript complains `registrationInfo` might be undefined even though `verified` is `true`.
However from looking at the code it seems like `registrationInfo` can never be undefined when `verified` is `true`.

This PR changes the Types to reflect that behavior and adjusts the return of `verifyRegistrationResponse` to fix resulting TypeScript errors where TypeScript can't ensure the types otherwise.

No behavior is changed to my knowledge and I kept the changes to a minimum. Though maybe it makes sense to split out a type for `registrationInfo`. 
It might create new errors and thus break existing type checks. But I see those as a feature as they might uncover bugs. 😅