### PR TITLE
Make `VerifiedRegistrationResponse` into a stricter type

### DIFF
--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -275,16 +275,15 @@ export async function verifyRegistrationResponse(
     throw new Error(`Unsupported Attestation Format: ${fmt}`);
   }
 
-  const toReturn: VerifiedRegistrationResponse = {
-    verified,
-  };
+  if (!verified) {
+    return { verified: false };
+  }
 
-  if (toReturn.verified) {
-    const { credentialDeviceType, credentialBackedUp } = parseBackupFlags(
-      flags,
-    );
+  const { credentialDeviceType, credentialBackedUp } = parseBackupFlags(flags);
 
-    toReturn.registrationInfo = {
+  return {
+    verified: true,
+    registrationInfo: {
       fmt,
       aaguid: convertAAGUIDToString(aaguid),
       credentialType,
@@ -301,10 +300,8 @@ export async function verifyRegistrationResponse(
       origin: clientDataJSON.origin,
       rpID: matchedRPID,
       authenticatorExtensionResults: extensionsData,
-    };
-  }
-
-  return toReturn;
+    },
+  };
 }
 
 /**

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -334,8 +334,11 @@ export async function verifyRegistrationResponse(
  * by the browser
  */
 export type VerifiedRegistrationResponse = {
-  verified: boolean;
-  registrationInfo?: {
+  verified: false;
+  registrationInfo?: never;
+} | {
+  verified: true;
+  registrationInfo: {
     fmt: AttestationFormat;
     aaguid: string;
     credential: WebAuthnCredential;


### PR DESCRIPTION
This PR updates **@simplewebauthn/server**'s `verifyRegistrationResponse()` to more clearly indicate, via improved typing, that `VerifiedRegistrationResponse.registrationInfo` will only ever be present when `VerifiedRegistrationResponse.verified` is `true`. This should empower developers to only have to check that `verified` is true before digging into `registrationInfo`.

Fixes #714.