### PR TITLE
Add new Server publish workflow

### DIFF
--- a/.github/workflows/publishServer.yml
+++ b/.github/workflows/publishServer.yml
@@ -55,6 +55,6 @@ jobs:
 
       # Publish to JSR and NPM
       - name: Publish to JSR and NPM
-        run: 'deno task publish:server'
+        run: deno task publish:server
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publishServer.yml
+++ b/.github/workflows/publishServer.yml
@@ -1,0 +1,60 @@
+name: Publish to JSR and NPM?
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with JSR.
+
+    env:
+      NODE_VERSION: '22.x'
+      DENO_VERSION: 'v2.4.x'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Install Node
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Confirm installed Node version
+        run: node -v
+
+      # Install Deno
+      - name: Setup Deno ${{ env.DENO_VERSION }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Confirm installed Deno version
+        run: deno -V
+
+      # Set up caching for quicker installs
+      - name: Get DENO_DIR store directory
+        shell: bash
+        # Expecting "DENO_DIR location: /Users/matt/Library/Caches/deno" somewhere in `deno info`
+        run: |
+          echo "DENO_DIR=$(deno info | grep "DENO_DIR" | awk '{print $3}')" >> $GITHUB_ENV
+      - name: Setup Deno cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-deno-dir-${{ hashFiles('**/deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-dir-
+
+      # Install deps
+      - name: Install dependencies
+        run: deno install
+
+      # Publish to JSR and NPM
+      - name: Publish to JSR and NPM
+        run: 'deno task publish:server'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR defines a new workflow to publish packages to JSR and NPM via GitHub Actions. This is a manual workflow for now, as I experiment with this method of package publication.

The @simplewebauthn/server package on NPM had its settings adjusted as needed according to https://docs.npmjs.com/trusted-publishers.