### PR TITLE
Add new Browser publish workflow

### DIFF
--- a/.github/workflows/publishBrowser.yml
+++ b/.github/workflows/publishBrowser.yml
@@ -1,0 +1,62 @@
+name: Publish @simplewebauthn/browser
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with JSR and NPM
+
+    env:
+      NODE_VERSION: '22.x'
+      DENO_VERSION: 'v2.4.x'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Install Node
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade NPM
+        # Trusted Publishing requires at least npm 11.5.1
+        run: npm install -g npm@^11.5.1
+
+      - name: Confirm installed Node and NPM versions
+        run: 'echo "Node: $(node -v)" && echo "NPM: $(npm -v)"'
+
+      # Install Deno
+      - name: Setup Deno ${{ env.DENO_VERSION }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Confirm installed Deno version
+        run: deno -V
+
+      # Set up caching for quicker installs
+      - name: Get DENO_DIR store directory
+        shell: bash
+        # Expecting "DENO_DIR location: /Users/matt/Library/Caches/deno" somewhere in `deno info`
+        run: |
+          echo "DENO_DIR=$(deno info | grep "DENO_DIR" | awk '{print $3}')" >> $GITHUB_ENV
+      - name: Setup Deno cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-deno-dir-${{ hashFiles('**/deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-dir-
+
+      # Install deps
+      - name: Install dependencies
+        run: deno install
+
+      # Publish to JSR and NPM
+      - name: Publish to JSR and NPM
+        run: deno task publish:browser

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -39,28 +39,22 @@ Add entries to CHANGELOG.md for the packages determined in the step above.
 
 Commit these changes.
 
-### Step 4: Publish packages
-
-The following commands can be run from the root of the monorepo to build the respective package,
-then **publish it to both [NPM](https://www.npmjs.com/search?q=%40simplewebauthn) and
-[JSR](https://jsr.io/@simplewebauthn)**.
-
-#### Need to publish @simplewebauthn/browser?
-
-```
-deno task publish:browser
-```
-
-#### Need to publish @simplewebauthn/server?
-
-```
-deno task publish:server
-```
-
-### Step 5: Create a git tag for the chosen version
+### Step 4: Create a git tag for the chosen version
 
 Create a tag on HEAD for the new version number.
 
-### Step 6: Push up `HEAD` to `origin`
+### Step 5: Push up `HEAD` to `origin`
 
-Don't forget to push up the latest changes to `origin` when everything's been published!
+Don't forget to push up the new tag to `origin` too!
+
+### Step 6: Publish packages
+
+#### Need to publish @simplewebauthn/browser?
+
+Navigate to https://github.com/MasterKale/SimpleWebAuthn/actions/workflows/publishBrowser.yml and
+**Run workflow** against **master**.
+
+#### Need to publish @simplewebauthn/server?
+
+Navigate to https://github.com/MasterKale/SimpleWebAuthn/actions/workflows/publicServer.yml and
+**Run workflow** against **master**.


### PR DESCRIPTION
On the heels of #725, this PR adds a new GitHub Actions-based publication workflow for **@simplewebauthn/browser**.

The **@simplewebauthn/browsert** package on NPM had its settings adjusted as needed according to https://docs.npmjs.com/trusted-publishers.

Fixes #676.