### PR TITLE
Add new browserSupportsPasskeys helper

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [master, beta]
   pull_request:
-    branches: [master, beta]
 
 jobs:
   unit_tests:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,13 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "deno.path": "/Users/matt/.dvm/bin/deno",
   "deno.enable": true,
   "deno.config": "./deno.json",
   "deno.disablePaths": [
     "./scratchenv",
-    "./example"
+    "./example",
+    "./cov_profile"
   ],
   "editor.rulers": [
     100

--- a/packages/browser/src/helpers/browserSupportsPasskeys.test.ts
+++ b/packages/browser/src/helpers/browserSupportsPasskeys.test.ts
@@ -1,0 +1,77 @@
+/// <reference lib="DOM" />
+import { assert, assertFalse } from '@std/assert';
+import { returnsNext, stub } from '@std/testing/mock';
+import { browserSupportsPasskeys } from './browserSupportsPasskeys.ts';
+import { _getBrowserCapabilitiesInternals } from './getBrowserCapabilities.ts';
+
+Deno.test('Returns true when passkeyPlatformAuthenticator capability is supported', async () => {
+  // @ts-ignore: Setting up global state
+  globalThis.PublicKeyCredential = () => {};
+
+  const mockGetBrowserCapabilities = stub(
+    _getBrowserCapabilitiesInternals,
+    'stubThis',
+    // @ts-ignore: Keeping tests lean
+    returnsNext([{ passkeyPlatformAuthenticator: 'supported' }]),
+  );
+
+  const supported = await browserSupportsPasskeys();
+
+  assert(supported);
+
+  mockGetBrowserCapabilities.restore();
+});
+
+Deno.test('Returns true when userVerifyingPlatformAuthenticator capability is supported', async () => {
+  // @ts-ignore: Setting up global state
+  globalThis.PublicKeyCredential = () => {};
+
+  const mockGetBrowserCapabilities = stub(
+    _getBrowserCapabilitiesInternals,
+    'stubThis',
+    // @ts-ignore: Keeping tests lean
+    returnsNext([{ userVerifyingPlatformAuthenticator: 'supported' }]),
+  );
+
+  const supported = await browserSupportsPasskeys();
+
+  assert(supported);
+
+  mockGetBrowserCapabilities.restore();
+});
+
+Deno.test('Returns true when hybridTransport capability is supported', async () => {
+  // @ts-ignore: Setting up global state
+  globalThis.PublicKeyCredential = () => {};
+
+  const mockGetBrowserCapabilities = stub(
+    _getBrowserCapabilitiesInternals,
+    'stubThis',
+    // @ts-ignore: Keeping tests lean
+    returnsNext([{ hybridTransport: 'supported' }]),
+  );
+
+  const supported = await browserSupportsPasskeys();
+
+  assert(supported);
+
+  mockGetBrowserCapabilities.restore();
+});
+
+Deno.test('Returns false when no relevant capabilities are supported', async () => {
+  // @ts-ignore: Setting up global state
+  globalThis.PublicKeyCredential = () => {};
+
+  const mockGetBrowserCapabilities = stub(
+    _getBrowserCapabilitiesInternals,
+    'stubThis',
+    // @ts-ignore: Keeping tests lean
+    returnsNext([{}]),
+  );
+
+  const supported = await browserSupportsPasskeys();
+
+  assertFalse(supported);
+
+  mockGetBrowserCapabilities.restore();
+});

--- a/packages/browser/src/helpers/browserSupportsPasskeys.ts
+++ b/packages/browser/src/helpers/browserSupportsPasskeys.ts
@@ -1,0 +1,24 @@
+import { browserSupportsWebAuthn } from './browserSupportsWebAuthn.ts';
+import { getBrowserCapabilities } from './getBrowserCapabilities.ts';
+
+/**
+ * Determine if the browser is capable of facilitating use of synced passkeys for **authentication**
+ * via local platform authenticator or via the hybrid transport. This method does NOT know if the
+ * user actually has a passkey available to use.
+ */
+export async function browserSupportsPasskeys(): Promise<boolean> {
+  if (!browserSupportsWebAuthn()) {
+    return new Promise((resolve) => resolve(false));
+  }
+
+  const capabilities = await getBrowserCapabilities();
+  const {
+    passkeyPlatformAuthenticator,
+    userVerifyingPlatformAuthenticator,
+    hybridTransport,
+  } = capabilities;
+
+  return passkeyPlatformAuthenticator === 'supported' ||
+    hybridTransport === 'supported' ||
+    userVerifyingPlatformAuthenticator === 'supported';
+}

--- a/packages/browser/src/helpers/getBrowserCapabilities.test.ts
+++ b/packages/browser/src/helpers/getBrowserCapabilities.test.ts
@@ -1,0 +1,81 @@
+/// <reference lib="DOM" />
+import { assertEquals } from '@std/assert';
+import { getBrowserCapabilities } from './getBrowserCapabilities.ts';
+
+Deno.test('Maps raw capabilities to string values', async () => {
+  // @ts-ignore: Set up PublicKeyCredential
+  globalThis.PublicKeyCredential = () => {};
+  globalThis.PublicKeyCredential.getClientCapabilities = () =>
+    new Promise((resolve) => {
+      resolve({
+        conditionalCreate: true,
+        conditionalGet: true,
+        hybridTransport: true,
+        passkeyPlatformAuthenticator: false,
+        userVerifyingPlatformAuthenticator: false,
+        relatedOrigins: false,
+        // These values are missing
+        // signalAllAcceptedCredentials: undefined,
+        // signalCurrentUserDetails: undefined,
+        // signalUnknownCredential: undefined,
+      });
+    });
+
+  const capabilities = await getBrowserCapabilities();
+
+  assertEquals(
+    capabilities,
+    {
+      conditionalCreate: 'supported',
+      conditionalGet: 'supported',
+      hybridTransport: 'supported',
+      passkeyPlatformAuthenticator: 'unsupported',
+      userVerifyingPlatformAuthenticator: 'unsupported',
+      relatedOrigins: 'unsupported',
+      signalAllAcceptedCredentials: 'unknown',
+      signalCurrentUserDetails: 'unknown',
+      signalUnknownCredential: 'unknown',
+    },
+  );
+});
+
+Deno.test('Works even when getClientCapabilities is missing', async () => {
+  // @ts-ignore: Pretend the method doesn't exist
+  globalThis.PublicKeyCredential = () => {};
+
+  const capabilities = await getBrowserCapabilities();
+
+  for (const [key, value] of Object.entries(capabilities)) {
+    assertEquals(value, 'unknown', `capability "${key}" was not "unknown"`);
+  }
+});
+
+Deno.test('Determines userVerifyingPlatformAuthenticator support via alternative means', async () => {
+  // @ts-ignore: Pretend the method doesn't exist
+  globalThis.PublicKeyCredential = () => {};
+  globalThis.PublicKeyCredential.getClientCapabilities = () =>
+    new Promise((resolve) => {
+      // Equivalent to all features being `undefined`
+      resolve({});
+    });
+  globalThis.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = async () => true;
+
+  const capabilities = await getBrowserCapabilities();
+
+  assertEquals(capabilities.userVerifyingPlatformAuthenticator, 'supported');
+});
+
+Deno.test('Determines conditionalGet support via alternative means', async () => {
+  // @ts-ignore: Pretend the method doesn't exist
+  globalThis.PublicKeyCredential = () => {};
+  globalThis.PublicKeyCredential.getClientCapabilities = () =>
+    new Promise((resolve) => {
+      // Equivalent to all features being `undefined`
+      resolve({});
+    });
+  globalThis.PublicKeyCredential.isConditionalMediationAvailable = async () => true;
+
+  const capabilities = await getBrowserCapabilities();
+
+  assertEquals(capabilities.conditionalGet, 'supported');
+});

--- a/packages/browser/src/helpers/getBrowserCapabilities.ts
+++ b/packages/browser/src/helpers/getBrowserCapabilities.ts
@@ -1,0 +1,161 @@
+/**
+ * A helper method that wraps WebAuthn's
+ * [`PublicKeyCredential.getClientCapabilities()`](https://w3c.github.io/webauthn/#sctn-getClientCapabilities)
+ * feature detection method. This method includes efforts to determine a feature's availability if a
+ * browser reports an "unknown" level of support for it but there exists an alternative WebAuthn API
+ * that reports the feature's availability.
+ *
+ * Capabilities are mapped to one of the following values:
+ *
+ * - **supported**: The browser supports the capability
+ * - **unsupported**: The browser does not support the capability
+ * - **unknown**: The browser may or may not support the capability, try it and see
+ *
+ * **Note:** If a WebAuthn client other than the browser is handling WebAuthn API calls (e.g. a
+ * password manager's browser extension) then this method will report that client's capabilities
+ * instead (assuming that client has implemented `PublicKeyCredential.getClientCapabilities()`.)
+ */
+export async function getBrowserCapabilities(): Promise<BrowserCapabilities> {
+  if (typeof PublicKeyCredential.getClientCapabilities === 'function') {
+    const capabilities = await PublicKeyCredential
+      .getClientCapabilities() as PublicKeyCredentialClientCapabilities;
+
+    /**
+     * The `userVerifyingPlatformAuthenticator` capability and `isUVPAA()` return value are
+     * equivalent, so we can fall back to the value of the latter when the capability is unknown.
+     *
+     * https://w3c.github.io/webauthn/#dom-clientcapability-userverifyingplatformauthenticator
+     */
+    let _userVerifyingPlatformAuthenticator = mapCapabilityToEnum(
+      capabilities.userVerifyingPlatformAuthenticator,
+    );
+
+    if (
+      _userVerifyingPlatformAuthenticator === 'unknown' &&
+      typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === 'function'
+    ) {
+      const isUVPAA = await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+      if (isUVPAA) {
+        _userVerifyingPlatformAuthenticator = 'supported';
+      } else {
+        _userVerifyingPlatformAuthenticator = 'unsupported';
+      }
+    }
+
+    /**
+     * The `conditionalGet` capability and `isConditionalMediationAvailable()` return value are
+     * equivalent, so we can fall back to the value of the latter when the capability is unknown.
+     *
+     * https://w3c.github.io/webauthn/#dom-clientcapability-conditionalget
+     */
+    let _conditionalGet = mapCapabilityToEnum(capabilities.conditionalGet);
+    if (
+      _conditionalGet === 'unknown' &&
+      typeof PublicKeyCredential.isConditionalMediationAvailable === 'function'
+    ) {
+      const isCMA = await PublicKeyCredential.isConditionalMediationAvailable();
+      if (isCMA) {
+        _conditionalGet = 'supported';
+      } else {
+        _conditionalGet = 'unsupported';
+      }
+    }
+
+    return _getBrowserCapabilitiesInternals.stubThis({
+      conditionalCreate: mapCapabilityToEnum(capabilities.conditionalCreate),
+      conditionalGet: _conditionalGet,
+      hybridTransport: mapCapabilityToEnum(capabilities.hybridTransport),
+      passkeyPlatformAuthenticator: mapCapabilityToEnum(capabilities.passkeyPlatformAuthenticator),
+      userVerifyingPlatformAuthenticator: _userVerifyingPlatformAuthenticator,
+      relatedOrigins: mapCapabilityToEnum(capabilities.relatedOrigins),
+      signalAllAcceptedCredentials: mapCapabilityToEnum(capabilities.signalAllAcceptedCredentials),
+      signalCurrentUserDetails: mapCapabilityToEnum(capabilities.signalCurrentUserDetails),
+      signalUnknownCredential: mapCapabilityToEnum(capabilities.signalUnknownCredential),
+    });
+  }
+
+  return _getBrowserCapabilitiesInternals.stubThis({
+    conditionalCreate: 'unknown',
+    conditionalGet: 'unknown',
+    hybridTransport: 'unknown',
+    passkeyPlatformAuthenticator: 'unknown',
+    userVerifyingPlatformAuthenticator: 'unknown',
+    relatedOrigins: 'unknown',
+    signalAllAcceptedCredentials: 'unknown',
+    signalCurrentUserDetails: 'unknown',
+    signalUnknownCredential: 'unknown',
+  });
+}
+
+/**
+ * One of the following values:
+ *
+ * - **supported**: The browser supports the corresponding capability
+ * - **unsupported**: The browser does not support the corresponding capability
+ * - **unknown**: The browser may or may not support the capability, try it and see
+ */
+export type BrowserCapabilitySupport = 'supported' | 'unsupported' | 'unknown';
+
+/**
+ * Various WebAuthn features the browser may support. See each property's description for more info.
+ */
+export type BrowserCapabilities = {
+  /** The browser can facilitate silent passkey registration after a successful auth */
+  conditionalCreate: BrowserCapabilitySupport;
+  /** The browser supports autofill UI to present available passkeys */
+  conditionalGet: BrowserCapabilitySupport;
+  /** The browser can communicate with another device via the hybrid transport to use a passkey */
+  hybridTransport: BrowserCapabilitySupport;
+  /** The browser can use a local platform authenticator, or a platform authenticator available on another device via the hybrid transport  */
+  passkeyPlatformAuthenticator: BrowserCapabilitySupport;
+  /** The browser can use a locally available user-verifying platform authenticator */
+  userVerifyingPlatformAuthenticator: BrowserCapabilitySupport;
+  /** The browser can facilitate use of a passkey, bound to one RP ID, across different origins */
+  relatedOrigins: BrowserCapabilitySupport;
+  /** The browser supports the signal API that communicates the user's current allowed passkeys for this site */
+  signalAllAcceptedCredentials: BrowserCapabilitySupport;
+  /** The browser supports the signal API that communicates the user's current metadata */
+  signalCurrentUserDetails: BrowserCapabilitySupport;
+  /** The browser supports the signal API that communicates an invalid credential ID */
+  signalUnknownCredential: BrowserCapabilitySupport;
+};
+
+/**
+ * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
+ * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * simply be that the browser has chosen not to divulge its support for the capability as a more
+ * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
+ * user privacy against the goals of the browser.
+ */
+type PublicKeyCredentialClientCapabilities = {
+  conditionalCreate?: boolean;
+  conditionalGet?: boolean;
+  hybridTransport?: boolean;
+  passkeyPlatformAuthenticator?: boolean;
+  userVerifyingPlatformAuthenticator?: boolean;
+  relatedOrigins?: boolean;
+  signalAllAcceptedCredentials?: boolean;
+  signalCurrentUserDetails?: boolean;
+  signalUnknownCredential?: boolean;
+};
+
+/**
+ * Map the tri-state booleans in `PublicKeyCredential.getClientCapablities()` to more descriptive
+ * values instead.
+ */
+function mapCapabilityToEnum(value?: boolean): BrowserCapabilitySupport {
+  if (value === true) {
+    return 'supported';
+  } else if (value === false) {
+    return 'unsupported';
+  } else if (typeof value === 'undefined') {
+    return 'unknown';
+  } else {
+    throw new Error('Unexpected capability value:', value);
+  }
+}
+
+// Make it possible to stub the return value during testing
+export const _getBrowserCapabilitiesInternals = {
+  stubThis: (value: BrowserCapabilities) => value,
+};

--- a/packages/browser/src/helpers/getBrowserCapabilities.ts
+++ b/packages/browser/src/helpers/getBrowserCapabilities.ts
@@ -1,3 +1,5 @@
+import type { PublicKeyCredentialClientCapabilities } from '../types/index.ts';
+
 /**
  * A helper method that wraps WebAuthn's
  * [`PublicKeyCredential.getClientCapabilities()`](https://w3c.github.io/webauthn/#sctn-getClientCapabilities)

--- a/packages/browser/src/helpers/getBrowserCapabilities.ts
+++ b/packages/browser/src/helpers/getBrowserCapabilities.ts
@@ -121,25 +121,6 @@ export type BrowserCapabilities = {
 };
 
 /**
- * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
- * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
- * simply be that the browser has chosen not to divulge its support for the capability as a more
- * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
- * user privacy against the goals of the browser.
- */
-type PublicKeyCredentialClientCapabilities = {
-  conditionalCreate?: boolean;
-  conditionalGet?: boolean;
-  hybridTransport?: boolean;
-  passkeyPlatformAuthenticator?: boolean;
-  userVerifyingPlatformAuthenticator?: boolean;
-  relatedOrigins?: boolean;
-  signalAllAcceptedCredentials?: boolean;
-  signalCurrentUserDetails?: boolean;
-  signalUnknownCredential?: boolean;
-};
-
-/**
  * Map the tri-state booleans in `PublicKeyCredential.getClientCapablities()` to more descriptive
  * values instead.
  */

--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -34,3 +34,11 @@ Deno.test('should export method `bufferToBase64URLString`', () => {
 Deno.test('should export singleton `WebAuthnAbortService`', () => {
   assert(index.WebAuthnAbortService);
 });
+
+Deno.test('should export method `getBrowserCapabilities`', () => {
+  assert(index.getBrowserCapabilities);
+});
+
+Deno.test('should export method `browserSupportsPasskeys`', () => {
+  assert(index.browserSupportsPasskeys);
+});

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -5,6 +5,7 @@ export * from './helpers/platformAuthenticatorIsAvailable.ts';
 export * from './helpers/browserSupportsWebAuthnAutofill.ts';
 export * from './helpers/base64URLStringToBuffer.ts';
 export * from './helpers/bufferToBase64URLString.ts';
+export * from './helpers/getBrowserCapabilities.ts';
 export * from './helpers/webAuthnAbortService.ts';
 export * from './helpers/webAuthnError.ts';
 export * from './types/index.ts';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,6 +1,7 @@
 export * from './methods/startRegistration.ts';
 export * from './methods/startAuthentication.ts';
 export * from './helpers/browserSupportsWebAuthn.ts';
+export * from './helpers/browserSupportsPasskeys.ts';
 export * from './helpers/platformAuthenticatorIsAvailable.ts';
 export * from './helpers/browserSupportsWebAuthnAutofill.ts';
 export * from './helpers/base64URLStringToBuffer.ts';

--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -299,15 +299,16 @@ export type AttestationFormat =
   | 'none';
 
 /**
- * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
- * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * More specific values available from `PublicKeyCredential.getClientCapabilities()`.
+ *
+ * A capability with an `undefined` value does not mean the feature is unsupported. It may
  * simply be that the browser has chosen not to divulge its support for the capability as a more
  * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
  * user privacy against the goals of the browser.
  *
  * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
  */
-type PublicKeyCredentialClientCapabilities = {
+export type PublicKeyCredentialClientCapabilities = {
   conditionalCreate?: boolean;
   conditionalGet?: boolean;
   hybridTransport?: boolean;

--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -258,6 +258,8 @@ export interface PublicKeyCredentialFuture extends PublicKeyCredential {
   ): PublicKeyCredentialRequestOptions;
   // See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
   toJSON(): PublicKeyCredentialJSON;
+  // See https://w3c.github.io/webauthn/#sctn-getClientCapabilities
+  getClientCapabilities?(): Promise<PublicKeyCredentialClientCapabilities>;
 }
 
 /**
@@ -295,6 +297,27 @@ export type AttestationFormat =
   | 'tpm'
   | 'apple'
   | 'none';
+
+/**
+ * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
+ * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * simply be that the browser has chosen not to divulge its support for the capability as a more
+ * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
+ * user privacy against the goals of the browser.
+ *
+ * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
+ */
+type PublicKeyCredentialClientCapabilities = {
+  conditionalCreate?: boolean;
+  conditionalGet?: boolean;
+  hybridTransport?: boolean;
+  passkeyPlatformAuthenticator?: boolean;
+  userVerifyingPlatformAuthenticator?: boolean;
+  relatedOrigins?: boolean;
+  signalAllAcceptedCredentials?: boolean;
+  signalCurrentUserDetails?: boolean;
+  signalUnknownCredential?: boolean;
+};
 
 /**
  * Equivalent to `Uint8Array` before TypeScript 5.7, and `Uint8Array<ArrayBuffer>` in TypeScript 5.7

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -299,15 +299,16 @@ export type AttestationFormat =
   | 'none';
 
 /**
- * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
- * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * More specific values available from `PublicKeyCredential.getClientCapabilities()`.
+ *
+ * A capability with an `undefined` value does not mean the feature is unsupported. It may
  * simply be that the browser has chosen not to divulge its support for the capability as a more
  * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
  * user privacy against the goals of the browser.
  *
  * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
  */
-type PublicKeyCredentialClientCapabilities = {
+export type PublicKeyCredentialClientCapabilities = {
   conditionalCreate?: boolean;
   conditionalGet?: boolean;
   hybridTransport?: boolean;

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -258,6 +258,8 @@ export interface PublicKeyCredentialFuture extends PublicKeyCredential {
   ): PublicKeyCredentialRequestOptions;
   // See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
   toJSON(): PublicKeyCredentialJSON;
+  // See https://w3c.github.io/webauthn/#sctn-getClientCapabilities
+  getClientCapabilities?(): Promise<PublicKeyCredentialClientCapabilities>;
 }
 
 /**
@@ -295,6 +297,27 @@ export type AttestationFormat =
   | 'tpm'
   | 'apple'
   | 'none';
+
+/**
+ * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
+ * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * simply be that the browser has chosen not to divulge its support for the capability as a more
+ * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
+ * user privacy against the goals of the browser.
+ *
+ * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
+ */
+type PublicKeyCredentialClientCapabilities = {
+  conditionalCreate?: boolean;
+  conditionalGet?: boolean;
+  hybridTransport?: boolean;
+  passkeyPlatformAuthenticator?: boolean;
+  userVerifyingPlatformAuthenticator?: boolean;
+  relatedOrigins?: boolean;
+  signalAllAcceptedCredentials?: boolean;
+  signalCurrentUserDetails?: boolean;
+  signalUnknownCredential?: boolean;
+};
 
 /**
  * Equivalent to `Uint8Array` before TypeScript 5.7, and `Uint8Array<ArrayBuffer>` in TypeScript 5.7

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -248,6 +248,8 @@ export interface PublicKeyCredentialFuture extends PublicKeyCredential {
   ): PublicKeyCredentialRequestOptions;
   // See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
   toJSON(): PublicKeyCredentialJSON;
+  // See https://w3c.github.io/webauthn/#sctn-getClientCapabilities
+  getClientCapabilities?(): Promise<PublicKeyCredentialClientCapabilities>;
 }
 
 /**
@@ -285,6 +287,27 @@ export type AttestationFormat =
   | 'tpm'
   | 'apple'
   | 'none';
+
+/**
+ * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
+ * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * simply be that the browser has chosen not to divulge its support for the capability as a more
+ * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
+ * user privacy against the goals of the browser.
+ *
+ * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
+ */
+type PublicKeyCredentialClientCapabilities = {
+  conditionalCreate?: boolean;
+  conditionalGet?: boolean;
+  hybridTransport?: boolean;
+  passkeyPlatformAuthenticator?: boolean;
+  userVerifyingPlatformAuthenticator?: boolean;
+  relatedOrigins?: boolean;
+  signalAllAcceptedCredentials?: boolean;
+  signalCurrentUserDetails?: boolean;
+  signalUnknownCredential?: boolean;
+};
 
 /**
  * Equivalent to `Uint8Array` before TypeScript 5.7, and `Uint8Array<ArrayBuffer>` in TypeScript 5.7

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -289,15 +289,16 @@ export type AttestationFormat =
   | 'none';
 
 /**
- * Typing specific to the PublicKeyCredential.getClientCapabilities() method that's being wrapped
- * above. A capability with an `undefined` value does not mean the feature is unsupported. It may
+ * More specific values available from `PublicKeyCredential.getClientCapabilities()`.
+ *
+ * A capability with an `undefined` value does not mean the feature is unsupported. It may
  * simply be that the browser has chosen not to divulge its support for the capability as a more
  * specific determination may be factored into e.g. ad-tech's browser fingerprinting that violates
  * user privacy against the goals of the browser.
  *
  * See https://w3c.github.io/webauthn/#typedefdef-publickeycredentialclientcapabilities
  */
-type PublicKeyCredentialClientCapabilities = {
+export type PublicKeyCredentialClientCapabilities = {
   conditionalCreate?: boolean;
   conditionalGet?: boolean;
   hybridTransport?: boolean;


### PR DESCRIPTION
This PR adds a new `browserSupportsPasskeys()` helper to **@simplewebauthn/browser** that returns a simple `true`/`false` if the browser supports use of synced passkeys for authentication. This method is a more use-case specific helper method than the existing `browserSupportsWebAuthn()` method which only determines basic WebAuthn availability. However, `browserSupportsPasskeys()` relies on `browserSupportsWebAuthn()` and so can be considered **an alternative method** for detecting passkey support.

This PR also exposes a new `getBrowserCapabilities()` helper method that wraps `PublicKeyCredential.getClientCapabilities()` and maps the original API's tri-state boolean (i.e. `true | false | undefined`) into discrete `"supported" | "unsupported" | "unknown"` values. Additional work is performed when a couple of capabilities are reported as `"unknown"` support but there exist alternative ways within WebAuthn to determine these capabilities' support.

Fixes #413.