### PR TITLE
Improve MetadataService logging

### DIFF
--- a/packages/server/src/helpers/index.ts
+++ b/packages/server/src/helpers/index.ts
@@ -15,3 +15,4 @@ export * from './verifySignature.ts';
 export * from './iso/index.ts';
 export * from '../metadata/verifyMDSBlob.ts';
 export * as cose from './cose.ts';
+export { type SimpleWebAuthnLogger } from './logging.ts';

--- a/packages/server/src/helpers/logging.test.ts
+++ b/packages/server/src/helpers/logging.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from '@std/assert';
+import { assertSpyCall, spy } from '@std/testing/mock';
+
+import { buildLoggerAllMethods } from './logging.ts';
+
+Deno.test('should define default methods for undefined methods', () => {
+  const logger = buildLoggerAllMethods({});
+
+  assertEquals(typeof logger.debug, 'function');
+  assertEquals(typeof logger.info, 'function');
+  assertEquals(typeof logger.warn, 'function');
+  assertEquals(typeof logger.error, 'function');
+});
+
+Deno.test('should use provided logger methods', () => {
+  const _debugSpy = spy();
+  const logger = buildLoggerAllMethods({ debug: _debugSpy });
+
+  logger.debug('SimpleWebAuthn');
+
+  assertEquals(logger.debug, _debugSpy);
+  assertSpyCall(_debugSpy, 0, { args: ['SimpleWebAuthn'], returned: undefined });
+});

--- a/packages/server/src/helpers/logging.test.ts
+++ b/packages/server/src/helpers/logging.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from '@std/assert';
-import { assertSpyCall, spy } from '@std/testing/mock';
+import { assertSpyCallArg, spy } from '@std/testing/mock';
 
 import { buildLoggerAllMethods } from './logging.ts';
 
@@ -19,5 +19,5 @@ Deno.test('should use provided logger methods', () => {
   logger.debug('SimpleWebAuthn');
 
   assertEquals(logger.debug, _debugSpy);
-  assertSpyCall(_debugSpy, 0, { args: ['SimpleWebAuthn'], returned: undefined });
+  assertSpyCallArg(_debugSpy, 0, 0, 'SimpleWebAuthn');
 });

--- a/packages/server/src/helpers/logging.ts
+++ b/packages/server/src/helpers/logging.ts
@@ -1,20 +1,22 @@
-// const defaultLogger = debug('SimpleWebAuthn');
-
 /**
- * Generate an instance of a `debug` logger that extends off of the "simplewebauthn" namespace for
- * consistent naming.
+ * A basic logging interface that enables projects to capture logging output from SimpleWebAuthn
+ * using whatever logging method is appropriate for the project.
  *
- * See https://www.npmjs.com/package/debug for information on how to control logging output when
- * using @simplewebauthn/server
+ * For example, a project using `console` statements to capture logs can use the following
+ * implementation of this interface:
  *
- * Example:
- *
- * ```
- * const log = getLogger('mds');
- * log('hello'); // simplewebauthn:mds hello +0ms
+ * ```ts
+ * const ConsoleLogger: SimpleWebAuthnLogger = {
+ *   debug(message: string, ...args: unknown[]) { console.debug(message, ...args); },
+ *   info(message: string, ...args: unknown[]) { console.info(message, ...args); },
+ *   warn(message: string, ...args: unknown[]) { console.warn(message, ...args); },
+ *   error(message: string, ...args: unknown[]) { console.error(message, ...args); },
+ * };
  * ```
  */
-export function getLogger(_name: string): (message: string, ..._rest: unknown[]) => void {
-  // This is a noop for now while I search for a better debug logger technique
-  return (_message, ..._rest) => {};
+export interface SimpleWebAuthnLogger {
+  debug: (message: string, ...args: unknown[]) => void;
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
 }

--- a/packages/server/src/helpers/logging.ts
+++ b/packages/server/src/helpers/logging.ts
@@ -20,3 +20,14 @@ export interface SimpleWebAuthnLogger {
   warn: (message: string, ...args: unknown[]) => void;
   error: (message: string, ...args: unknown[]) => void;
 }
+
+/**
+ * A logger instance that doesn't do anything. Useful as a default argument when no custom instance
+ * of the `SimpleWebAuthnLogger` interface is specified.
+ */
+export const DefaultNoopLogger: SimpleWebAuthnLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/packages/server/src/helpers/logging.ts
+++ b/packages/server/src/helpers/logging.ts
@@ -1,13 +1,14 @@
 /**
  * A basic logging interface that enables projects to capture logging output from SimpleWebAuthn
- * using whatever logging method is appropriate for the project.
+ * using whatever logging method is appropriate for the project. Logging levels can be defined
+ * independently to only capture desired levels.
  *
  * For example, a project using `console` statements to capture logs can use the following
  * implementation of this interface:
  *
  * ```ts
  * const ConsoleLogger: SimpleWebAuthnLogger = {
- *   debug(message: string, ...args: unknown[]) { console.debug(message, ...args); },
+ *   // debug(message: string, ...args: unknown[]) { console.debug(message, ...args); },
  *   info(message: string, ...args: unknown[]) { console.info(message, ...args); },
  *   warn(message: string, ...args: unknown[]) { console.warn(message, ...args); },
  *   error(message: string, ...args: unknown[]) { console.error(message, ...args); },
@@ -15,19 +16,47 @@
  * ```
  */
 export interface SimpleWebAuthnLogger {
-  debug: (message: string, ...args: unknown[]) => void;
-  info: (message: string, ...args: unknown[]) => void;
-  warn: (message: string, ...args: unknown[]) => void;
-  error: (message: string, ...args: unknown[]) => void;
+  debug?: (message: string, ...args: unknown[]) => void;
+  info?: (message: string, ...args: unknown[]) => void;
+  warn?: (message: string, ...args: unknown[]) => void;
+  error?: (message: string, ...args: unknown[]) => void;
 }
 
 /**
  * A logger instance that doesn't do anything. Useful as a default argument when no custom instance
  * of the `SimpleWebAuthnLogger` interface is specified.
  */
-export const DefaultNoopLogger: SimpleWebAuthnLogger = {
+export const DefaultNoopLogger: Required<SimpleWebAuthnLogger> = {
   debug() {},
   info() {},
   warn() {},
   error() {},
 };
+
+/**
+ * Generate an instance of SimpleWebAuthnLogger that defines all methods. Any logging method not
+ * defined on `logger` will be a no-op.
+ */
+export function buildLoggerAllMethods(
+  logger: SimpleWebAuthnLogger,
+): Required<SimpleWebAuthnLogger> {
+  const toReturn: Required<SimpleWebAuthnLogger> = { ...DefaultNoopLogger };
+
+  if (logger.debug) {
+    toReturn.debug = logger.debug;
+  }
+
+  if (logger.info) {
+    toReturn.info = logger.info;
+  }
+
+  if (logger.warn) {
+    toReturn.warn = logger.warn;
+  }
+
+  if (logger.error) {
+    toReturn.error = logger.error;
+  }
+
+  return toReturn;
+}

--- a/packages/server/src/services/metadataService.test.ts
+++ b/packages/server/src/services/metadataService.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import { assertSpyCallArg, assertSpyCalls, type Stub, stub } from '@std/testing/mock';
+import { assertSpyCallArg, assertSpyCalls, spy, type Stub, stub } from '@std/testing/mock';
 
 import { _fetchInternals } from '../helpers/fetch.ts';
 
@@ -92,6 +92,25 @@ describe('Method: getStatement()', () => {
     const statement = await MetadataService.getStatement('not-a-real-aaguid');
 
     assertEquals(statement, undefined);
+  });
+});
+
+describe('Behavior: logging', () => {
+  it('should use provided logger', async () => {
+    const _debugSpy = spy();
+
+    await MetadataService.initialize({
+      mdsServers: [],
+      statements: [],
+      logger: { debug: _debugSpy },
+    });
+
+    /**
+     * NOTE TO FUTURE SELF: As of June 2026 the content of the logging is less important here than
+     * the fact that the service used the provided logger to communicate internal goings on.
+     */
+    assertSpyCallArg(_debugSpy, 0, 0, 'MetadataService is REFRESHING');
+    assertSpyCallArg(_debugSpy, 1, 0, 'MetadataService is READY');
   });
 });
 

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -1,7 +1,7 @@
 import { convertAAGUIDToString } from '../helpers/convertAAGUIDToString.ts';
 import type { MetadataBLOBPayloadEntry, MetadataStatement } from '../metadata/mdsTypes.ts';
 import { verifyMDSBlob } from '../metadata/verifyMDSBlob.ts';
-import { getLogger } from '../helpers/logging.ts';
+import { DefaultNoopLogger, type SimpleWebAuthnLogger } from '../helpers/logging.ts';
 import { fetch } from '../helpers/fetch.ts';
 import type { Uint8Array_ } from '../types/index.ts';
 
@@ -44,8 +44,6 @@ enum SERVICE_STATE {
  */
 export type VerificationMode = 'permissive' | 'strict';
 
-const log = getLogger('MetadataService');
-
 interface MetadataService {
   /**
    * Prepare the service to handle remote MDS servers and/or cache local metadata statements.
@@ -65,6 +63,7 @@ interface MetadataService {
     mdsServers?: string[];
     statements?: MetadataStatement[];
     verificationMode?: VerificationMode;
+    logger?: SimpleWebAuthnLogger;
   }): Promise<void>;
   /**
    * Get a metadata statement for a given AAGUID.
@@ -86,18 +85,27 @@ export class BaseMetadataService implements MetadataService {
   private statementCache: { [aaguid: string]: CachedBLOBEntry } = {};
   private state: SERVICE_STATE = SERVICE_STATE.DISABLED;
   private verificationMode: VerificationMode = 'strict';
+  private logger: SimpleWebAuthnLogger = DefaultNoopLogger;
 
   async initialize(
     opts: {
       mdsServers?: string[];
       statements?: MetadataStatement[];
       verificationMode?: VerificationMode;
+      logger?: SimpleWebAuthnLogger;
     } = {},
   ): Promise<void> {
     // Reset statement cache
     this.statementCache = {};
 
-    const { mdsServers = [defaultURLMDS], statements, verificationMode } = opts;
+    const {
+      mdsServers = [defaultURLMDS],
+      statements,
+      verificationMode,
+      logger = DefaultNoopLogger,
+    } = opts;
+
+    this.logger = logger;
 
     this.setState(SERVICE_STATE.REFRESHING);
 
@@ -124,7 +132,7 @@ export class BaseMetadataService implements MetadataService {
         }
       });
 
-      log(`Cached ${statementsAdded} local statements`);
+      this.logger.info(`Cached ${statementsAdded} local statements`);
     }
 
     /**
@@ -149,7 +157,7 @@ export class BaseMetadataService implements MetadataService {
           await this.verifyBlob(blob, cachedMDS);
         } catch (err) {
           // Notify of the error and move on
-          log(`Could not download BLOB from ${url}:`, err);
+          this.logger.error(`Could not download BLOB from ${url}:`, err);
           numServers -= 1;
         }
       }
@@ -157,7 +165,7 @@ export class BaseMetadataService implements MetadataService {
       // Calculate the difference to get the total number of new statements we successfully added
       const newCacheCount = Object.keys(this.statementCache).length;
       const cacheDiff = newCacheCount - currentCacheCount;
-      log(
+      this.logger.info(
         `Cached ${cacheDiff} statements from ${numServers} metadata server(s)`,
       );
     }
@@ -288,7 +296,7 @@ export class BaseMetadataService implements MetadataService {
         // TODO (Feb 2026): It'd be more actionable for devs if a specific error was raised here,
         // then this message was logged higher up when it can include the array index of the stale
         // blob.
-        log(
+        this.logger.warn(
           `⚠️ This MDS blob (serial: ${payload.no}) contains stale data as of ${parsedNextUpdate.toISOString()}. Please consider re-initializing MetadataService with a newer MDS blob.`,
         );
       }
@@ -337,11 +345,11 @@ export class BaseMetadataService implements MetadataService {
     this.state = newState;
 
     if (newState === SERVICE_STATE.DISABLED) {
-      log('MetadataService is DISABLED');
+      this.logger.debug('MetadataService is DISABLED');
     } else if (newState === SERVICE_STATE.REFRESHING) {
-      log('MetadataService is REFRESHING');
+      this.logger.debug('MetadataService is REFRESHING');
     } else if (newState === SERVICE_STATE.READY) {
-      log('MetadataService is READY');
+      this.logger.debug('MetadataService is READY');
     }
   }
 }

--- a/packages/server/src/services/metadataService.ts
+++ b/packages/server/src/services/metadataService.ts
@@ -1,7 +1,11 @@
 import { convertAAGUIDToString } from '../helpers/convertAAGUIDToString.ts';
 import type { MetadataBLOBPayloadEntry, MetadataStatement } from '../metadata/mdsTypes.ts';
 import { verifyMDSBlob } from '../metadata/verifyMDSBlob.ts';
-import { DefaultNoopLogger, type SimpleWebAuthnLogger } from '../helpers/logging.ts';
+import {
+  buildLoggerAllMethods,
+  DefaultNoopLogger,
+  type SimpleWebAuthnLogger,
+} from '../helpers/logging.ts';
 import { fetch } from '../helpers/fetch.ts';
 import type { Uint8Array_ } from '../types/index.ts';
 
@@ -85,7 +89,7 @@ export class BaseMetadataService implements MetadataService {
   private statementCache: { [aaguid: string]: CachedBLOBEntry } = {};
   private state: SERVICE_STATE = SERVICE_STATE.DISABLED;
   private verificationMode: VerificationMode = 'strict';
-  private logger: SimpleWebAuthnLogger = DefaultNoopLogger;
+  private logger: Required<SimpleWebAuthnLogger> = DefaultNoopLogger;
 
   async initialize(
     opts: {
@@ -105,7 +109,7 @@ export class BaseMetadataService implements MetadataService {
       logger = DefaultNoopLogger,
     } = opts;
 
-    this.logger = logger;
+    this.logger = buildLoggerAllMethods(logger);
 
     this.setState(SERVICE_STATE.REFRESHING);
 


### PR DESCRIPTION
This PR introduces a new `logger` argument to `MetadataService.initialize()`. This argument is of type `SimpleWebAuthnLogger`, which is a simple object of logging methods:

```ts
export interface SimpleWebAuthnLogger {
  debug: (message: string, ...args: unknown[]) => void;
  info: (message: string, ...args: unknown[]) => void;
  warn: (message: string, ...args: unknown[]) => void;
  error: (message: string, ...args: unknown[]) => void;
}
```

The intention is that projects using SimpleWebAuthn can define an instance of this `interface` that logs the message and arbitrary arguments in a way that makes sense for that project. This eliminates any SimpleWebAuthn-specific logging concerns that led to the old implementation getting ripped out of this project.

Right now only `MetadataService` will make use of this new logging pattern.

Fixes #751.