### PR TITLE
Normalize TPM manufacturer IDs before lookup

### DIFF
--- a/packages/server/src/registration/verifications/tpm/constants.ts
+++ b/packages/server/src/registration/verifications/tpm/constants.ts
@@ -90,7 +90,7 @@ export const TPM_ECC_CURVE: { [key: number]: string } = {
   0x0020: 'TPM_ECC_SM2_P256',
 };
 
-type ManufacturerInfo = {
+export type ManufacturerInfo = {
   name: string;
   id: string;
 };

--- a/packages/server/src/registration/verifications/tpm/constants.ts
+++ b/packages/server/src/registration/verifications/tpm/constants.ts
@@ -113,8 +113,7 @@ export const TPM_MANUFACTURERS: { [key: string]: ManufacturerInfo } = {
   'id:48504900': { name: 'HPI', id: 'HPI' },
   'id:48504500': { name: 'HPE', id: 'HPE' },
   'id:48495349': { name: 'Huawei', id: 'HISI' },
-  'id:49424d00': { name: 'IBM', id: 'IBM' },
-  'id:49424D00': { name: 'IBM', id: 'IBM' }, // Same ID for IBM as above, except the "D" is capitalized as per TPM spec
+  'id:49424D00': { name: 'IBM', id: 'IBM' }, // IBM is "id:49424d00" in the TPM spec. It's been normalized here
   'id:49465800': { name: 'Infineon', id: 'IFX' },
   'id:494E5443': { name: 'Intel', id: 'INTC' },
   'id:4C454E00': { name: 'Lenovo', id: 'LEN' },

--- a/packages/server/src/registration/verifications/tpm/isValidTPMManufacturerID.test.ts
+++ b/packages/server/src/registration/verifications/tpm/isValidTPMManufacturerID.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from '@std/assert';
+import { getTPMManufacturerInfo } from './isValidTPMManufacturerID.ts';
+
+Deno.test('should normalize manufacturer ID - Qualcomm', () => {
+  const isValid = getTPMManufacturerInfo('id:51434f4d');
+
+  assertEquals(isValid?.id, 'QCOM');
+  assertEquals(isValid?.name, 'Qualcomm');
+});
+
+Deno.test('should normalize manufacturer ID - IBM', () => {
+  const isValid = getTPMManufacturerInfo('id:49424d00');
+
+  assertEquals(isValid?.id, 'IBM');
+  assertEquals(isValid?.name, 'IBM');
+});
+
+Deno.test('should return undefined for bad manufacturer ID', () => {
+  const isValid = getTPMManufacturerInfo('');
+
+  assertEquals(isValid, undefined);
+});

--- a/packages/server/src/registration/verifications/tpm/isValidTPMManufacturerID.ts
+++ b/packages/server/src/registration/verifications/tpm/isValidTPMManufacturerID.ts
@@ -1,0 +1,8 @@
+import { type ManufacturerInfo, TPM_MANUFACTURERS } from './constants.ts';
+
+export function getTPMManufacturerInfo(id: string): ManufacturerInfo | undefined {
+  // e.g. "id:51434f4d" -> "id:51434f4D"
+  const _normalized = `id:${id.substring(3).toUpperCase()}`;
+
+  return TPM_MANUFACTURERS[_normalized];
+}

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.ts
@@ -28,9 +28,10 @@ import { MetadataService } from '../../../services/metadataService.ts';
 import { verifyAttestationWithMetadata } from '../../../metadata/verifyAttestationWithMetadata.ts';
 import type { Uint8Array_ } from '../../../types/index.ts';
 
-import { TPM_ECC_CURVE_COSE_CRV_MAP, TPM_MANUFACTURERS } from './constants.ts';
+import { TPM_ECC_CURVE_COSE_CRV_MAP } from './constants.ts';
 import { parseCertInfo } from './parseCertInfo.ts';
 import { parsePubArea } from './parsePubArea.ts';
+import { getTPMManufacturerInfo } from './isValidTPMManufacturerID.ts';
 
 export async function verifyAttestationTPM(
   options: AttestationFormatVerifierOpts,
@@ -325,7 +326,7 @@ export async function verifyAttestationTPM(
   }
 
   // Check that tcpaTpmManufacturer (2.23.133.2.1) field is set to a valid manufacturer ID.
-  if (!TPM_MANUFACTURERS[tcgAtTpmManufacturer]) {
+  if (!getTPMManufacturerInfo(tcgAtTpmManufacturer)) {
     throw new Error(
       `Could not match TPM manufacturer "${tcgAtTpmManufacturer}" (TPM)`,
     );


### PR DESCRIPTION
This PR updates TPM attestation statement verification to normalize TPM manufacturer IDs before checking to make sure it's a recognized one.

Fixes #769.