### PR TITLE
Add Deno v2.8.x to support matrix

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [22, 24, 26]
-        deno-version: ['v2.4.x', 'v2.5.x', 'v2.6.x', 'v2.7.x']
+        deno-version: ['v2.4.x', 'v2.5.x', 'v2.6.x', 'v2.7.x', 'v2.8.x']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Deno released [v2.8.0](https://github.com/denoland/deno/releases/tag/v2.8.0) on May 22, 2026, so it's time to add v2.8.x to the CI testing matrix. Let's see if anything breaks.