### PR TITLE
Simplify transports types

### DIFF
--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -2,6 +2,7 @@ import type {
   AuthenticatorTransport,
   PublicKeyCredentialDescriptor,
   PublicKeyCredentialDescriptorJSON,
+  PublicKeyCredentialType,
 } from '../types/index.ts';
 import { base64URLStringToBuffer } from './base64URLStringToBuffer.ts';
 
@@ -13,11 +14,7 @@ export function toPublicKeyCredentialDescriptor(
   return {
     ...descriptor,
     id: base64URLStringToBuffer(id),
-    /**
-     * `descriptor.transports` is an array of our `AuthenticatorTransportFuture` that includes newer
-     * transports that TypeScript's DOM lib is ignorant of. Convince TS that our list of transports
-     * are fine to pass to WebAuthn since browsers will recognize the new value.
-     */
     transports: descriptor.transports as AuthenticatorTransport[],
+    type: descriptor.type as PublicKeyCredentialType,
   };
 }

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -105,7 +105,7 @@ export async function startAuthentication(
   // Wait for the user to complete assertion
   let credential;
   try {
-    credential = (await navigator.credentials.get(getOptions as globalThis.CredentialRequestOptions)) as AuthenticationCredential;
+    credential = (await navigator.credentials.get(getOptions)) as AuthenticationCredential;
   } catch (err) {
     throw identifyAuthenticationError({ error: err as Error, options: getOptions });
   }

--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -105,7 +105,10 @@ export async function startAuthentication(
   // Wait for the user to complete assertion
   let credential;
   try {
-    credential = (await navigator.credentials.get(getOptions)) as AuthenticationCredential;
+    credential = (await navigator.credentials.get(
+      // TODO: Newer versions of Deno require this casting, revisit once we're using Deno 2.6+
+      getOptions as globalThis.CredentialRequestOptions,
+    )) as AuthenticationCredential;
   } catch (err) {
     throw identifyAuthenticationError({ error: err as Error, options: getOptions });
   }

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -1,5 +1,4 @@
 import type {
-  AuthenticatorTransportFuture,
   CredentialCreationOptions,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialCreationOptionsJSON,
@@ -90,7 +89,7 @@ export async function startRegistration(
   const { id, rawId, response, type } = credential;
 
   // Continue to play it safe with `getTransports()` for now, even when L3 types say it's required
-  let transports: AuthenticatorTransportFuture[] | undefined = undefined;
+  let transports: string[] | undefined = undefined;
   if (typeof response.getTransports === 'function') {
     transports = response.getTransports();
   }

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -77,7 +77,10 @@ export async function startRegistration(
   // Wait for the user to complete attestation
   let credential;
   try {
-    credential = (await navigator.credentials.create(createOptions)) as RegistrationCredential;
+    credential = (await navigator.credentials.create(
+      // TODO: Newer versions of Deno require this casting, revisit once we're using Deno 2.6+
+      createOptions as globalThis.CredentialCreationOptions,
+    )) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options: createOptions });
   }

--- a/packages/browser/src/methods/startRegistration.ts
+++ b/packages/browser/src/methods/startRegistration.ts
@@ -77,7 +77,7 @@ export async function startRegistration(
   // Wait for the user to complete attestation
   let credential;
   try {
-    credential = (await navigator.credentials.create(createOptions as globalThis.CredentialCreationOptions)) as RegistrationCredential;
+    credential = (await navigator.credentials.create(createOptions)) as RegistrationCredential;
   } catch (err) {
     throw identifyRegistrationError({ error: err as Error, options: createOptions });
   }

--- a/packages/browser/src/types/dom.ts
+++ b/packages/browser/src/types/dom.ts
@@ -136,6 +136,12 @@ export interface PublicKeyCredentialDescriptor {
     type: PublicKeyCredentialType;
 }
 
+export interface PublicKeyCredentialDescriptorJSON {
+    id: Base64URLString;
+    transports?: string[];
+    type: string;
+}
+
 export interface PublicKeyCredentialParameters {
     alg: COSEAlgorithmIdentifier;
     type: PublicKeyCredentialType;
@@ -592,6 +598,7 @@ export interface RsaKeyGenParams extends Algorithm {
 
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
+export type Base64URLString = string;
 export type COSEAlgorithmIdentifier = number;
 export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";

--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -16,10 +16,11 @@ import type {
   AuthenticatorAttachment,
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
-  PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -36,6 +37,7 @@ export type {
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
   AuthenticatorTransport,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   CredentialCreationOptions,
   CredentialRequestOptions,
@@ -43,6 +45,7 @@ export type {
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -90,15 +93,6 @@ export interface PublicKeyCredentialRequestOptionsJSON {
 }
 
 /**
- * https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptorjson
- */
-export interface PublicKeyCredentialDescriptorJSON {
-  id: Base64URLString;
-  type: PublicKeyCredentialType;
-  transports?: AuthenticatorTransportFuture[];
-}
-
-/**
  * https://w3c.github.io/webauthn/#dictdef-publickeycredentialuserentityjson
  */
 export interface PublicKeyCredentialUserEntityJSON {
@@ -111,7 +105,7 @@ export interface PublicKeyCredentialUserEntityJSON {
  * The value returned from navigator.credentials.create()
  */
 export interface RegistrationCredential extends PublicKeyCredentialFuture {
-  response: AuthenticatorAttestationResponseFuture;
+  response: AuthenticatorAttestationResponse;
 }
 
 /**
@@ -163,7 +157,7 @@ export interface AuthenticatorAttestationResponseJSON {
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   authenticatorData?: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
-  transports?: AuthenticatorTransportFuture[];
+  transports?: string[];
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   publicKeyAlgorithm?: COSEAlgorithmIdentifier;
   publicKey?: Base64URLString;
@@ -190,51 +184,9 @@ export type WebAuthnCredential = {
   publicKey: Uint8Array_;
   // Number of times this authenticator is expected to have been used
   counter: number;
-  // From browser's `startRegistration()` -> RegistrationCredentialJSON.transports (API L2 and up)
-  transports?: AuthenticatorTransportFuture[];
+  // From browser's `startRegistration()` -> RegistrationCredential.response.transports (API L2 and up)
+  transports?: string[];
 };
-
-/**
- * An attempt to communicate that this isn't just any string, but a Base64URL-encoded string
- */
-export type Base64URLString = string;
-
-/**
- * AuthenticatorAttestationResponse in TypeScript's DOM lib is outdated (up through v3.9.7).
- * Maintain an augmented version here so we can implement additional properties as the WebAuthn
- * spec evolves.
- *
- * See https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse
- *
- * Properties marked optional are not supported in all browsers.
- */
-export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAttestationResponse {
-  getTransports(): AuthenticatorTransportFuture[];
-}
-
-/**
- * A super class of TypeScript's `AuthenticatorTransport` that includes support for the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export type AuthenticatorTransportFuture =
-  | 'ble'
-  | 'cable'
-  | 'hybrid'
-  | 'internal'
-  | 'nfc'
-  | 'smart-card'
-  | 'usb';
-
-/**
- * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export interface PublicKeyCredentialDescriptorFuture
-  extends Omit<PublicKeyCredentialDescriptor, 'transports'> {
-  transports?: AuthenticatorTransportFuture[];
-}
 
 /** */
 export type PublicKeyCredentialJSON =

--- a/packages/server/src/authentication/generateAuthenticationOptions.ts
+++ b/packages/server/src/authentication/generateAuthenticationOptions.ts
@@ -1,6 +1,5 @@
 import type {
   AuthenticationExtensionsClientInputs,
-  AuthenticatorTransportFuture,
   Base64URLString,
   PublicKeyCredentialRequestOptionsJSON,
   Uint8Array_,
@@ -27,7 +26,7 @@ export async function generateAuthenticationOptions(
     rpID: string;
     allowCredentials?: {
       id: Base64URLString;
-      transports?: AuthenticatorTransportFuture[];
+      transports?: string[];
     }[];
     challenge?: string | Uint8Array_;
     timeout?: number;

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -1,7 +1,6 @@
 import type {
   AuthenticationExtensionsClientInputs,
   AuthenticatorSelectionCriteria,
-  AuthenticatorTransportFuture,
   Base64URLString,
   COSEAlgorithmIdentifier,
   PublicKeyCredentialCreationOptionsJSON,
@@ -94,7 +93,7 @@ export async function generateRegistrationOptions(
     attestationType?: 'direct' | 'enterprise' | 'none';
     excludeCredentials?: {
       id: Base64URLString;
-      transports?: AuthenticatorTransportFuture[];
+      transports?: string[];
     }[];
     authenticatorSelection?: AuthenticatorSelectionCriteria;
     extensions?: AuthenticationExtensionsClientInputs;

--- a/packages/server/src/types/dom.ts
+++ b/packages/server/src/types/dom.ts
@@ -136,6 +136,12 @@ export interface PublicKeyCredentialDescriptor {
     type: PublicKeyCredentialType;
 }
 
+export interface PublicKeyCredentialDescriptorJSON {
+    id: Base64URLString;
+    transports?: string[];
+    type: string;
+}
+
 export interface PublicKeyCredentialParameters {
     alg: COSEAlgorithmIdentifier;
     type: PublicKeyCredentialType;
@@ -592,6 +598,7 @@ export interface RsaKeyGenParams extends Algorithm {
 
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
+export type Base64URLString = string;
 export type COSEAlgorithmIdentifier = number;
 export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -16,10 +16,11 @@ import type {
   AuthenticatorAttachment,
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
-  PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -36,6 +37,7 @@ export type {
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
   AuthenticatorTransport,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   CredentialCreationOptions,
   CredentialRequestOptions,
@@ -43,6 +45,7 @@ export type {
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -90,15 +93,6 @@ export interface PublicKeyCredentialRequestOptionsJSON {
 }
 
 /**
- * https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptorjson
- */
-export interface PublicKeyCredentialDescriptorJSON {
-  id: Base64URLString;
-  type: PublicKeyCredentialType;
-  transports?: AuthenticatorTransportFuture[];
-}
-
-/**
  * https://w3c.github.io/webauthn/#dictdef-publickeycredentialuserentityjson
  */
 export interface PublicKeyCredentialUserEntityJSON {
@@ -111,7 +105,7 @@ export interface PublicKeyCredentialUserEntityJSON {
  * The value returned from navigator.credentials.create()
  */
 export interface RegistrationCredential extends PublicKeyCredentialFuture {
-  response: AuthenticatorAttestationResponseFuture;
+  response: AuthenticatorAttestationResponse;
 }
 
 /**
@@ -163,7 +157,7 @@ export interface AuthenticatorAttestationResponseJSON {
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   authenticatorData?: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
-  transports?: AuthenticatorTransportFuture[];
+  transports?: string[];
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   publicKeyAlgorithm?: COSEAlgorithmIdentifier;
   publicKey?: Base64URLString;
@@ -190,51 +184,9 @@ export type WebAuthnCredential = {
   publicKey: Uint8Array_;
   // Number of times this authenticator is expected to have been used
   counter: number;
-  // From browser's `startRegistration()` -> RegistrationCredentialJSON.transports (API L2 and up)
-  transports?: AuthenticatorTransportFuture[];
+  // From browser's `startRegistration()` -> RegistrationCredential.response.transports (API L2 and up)
+  transports?: string[];
 };
-
-/**
- * An attempt to communicate that this isn't just any string, but a Base64URL-encoded string
- */
-export type Base64URLString = string;
-
-/**
- * AuthenticatorAttestationResponse in TypeScript's DOM lib is outdated (up through v3.9.7).
- * Maintain an augmented version here so we can implement additional properties as the WebAuthn
- * spec evolves.
- *
- * See https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse
- *
- * Properties marked optional are not supported in all browsers.
- */
-export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAttestationResponse {
-  getTransports(): AuthenticatorTransportFuture[];
-}
-
-/**
- * A super class of TypeScript's `AuthenticatorTransport` that includes support for the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export type AuthenticatorTransportFuture =
-  | 'ble'
-  | 'cable'
-  | 'hybrid'
-  | 'internal'
-  | 'nfc'
-  | 'smart-card'
-  | 'usb';
-
-/**
- * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export interface PublicKeyCredentialDescriptorFuture
-  extends Omit<PublicKeyCredentialDescriptor, 'transports'> {
-  transports?: AuthenticatorTransportFuture[];
-}
 
 /** */
 export type PublicKeyCredentialJSON =

--- a/packages/types/extract-dom-types.ts
+++ b/packages/types/extract-dom-types.ts
@@ -53,6 +53,7 @@ const types = [
   'PublicKeyCredential',
   'PublicKeyCredentialCreationOptions',
   'PublicKeyCredentialDescriptor',
+  'PublicKeyCredentialDescriptorJSON',
   'PublicKeyCredentialParameters',
   'PublicKeyCredentialRequestOptions',
   'PublicKeyCredentialUserEntity',

--- a/packages/types/extract-dom-types.ts
+++ b/packages/types/extract-dom-types.ts
@@ -45,6 +45,7 @@ const types = [
   'AuthenticationExtensionsClientInputs',
   'AuthenticationExtensionsClientOutputs',
   'AuthenticatorSelectionCriteria',
+  'Base64URLString',
   'COSEAlgorithmIdentifier',
   'CredentialCreationOptions',
   'CredentialRequestOptions',

--- a/packages/types/src/dom.ts
+++ b/packages/types/src/dom.ts
@@ -128,6 +128,12 @@ export interface PublicKeyCredentialDescriptor {
     type: PublicKeyCredentialType;
 }
 
+export interface PublicKeyCredentialDescriptorJSON {
+    id: Base64URLString;
+    transports?: string[];
+    type: string;
+}
+
 export interface PublicKeyCredentialParameters {
     alg: COSEAlgorithmIdentifier;
     type: PublicKeyCredentialType;

--- a/packages/types/src/dom.ts
+++ b/packages/types/src/dom.ts
@@ -584,6 +584,7 @@ export interface RsaKeyGenParams extends Algorithm {
 
 export type AttestationConveyancePreference = "direct" | "enterprise" | "indirect" | "none";
 export type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
+export type Base64URLString = string;
 export type COSEAlgorithmIdentifier = number;
 export type ResidentKeyRequirement = "discouraged" | "preferred" | "required";
 export type UserVerificationRequirement = "discouraged" | "preferred" | "required";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,6 +11,7 @@ import type {
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -35,6 +36,7 @@ export type {
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptor,
+  PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
@@ -79,15 +81,6 @@ export interface PublicKeyCredentialRequestOptionsJSON {
   userVerification?: UserVerificationRequirement;
   hints?: PublicKeyCredentialHint[];
   extensions?: AuthenticationExtensionsClientInputs;
-}
-
-/**
- * https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptorjson
- */
-export interface PublicKeyCredentialDescriptorJSON {
-  id: Base64URLString;
-  type: PublicKeyCredentialType;
-  transports?: AuthenticatorTransportFuture[];
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ import type {
   AuthenticatorAttachment,
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
@@ -26,6 +27,7 @@ export type {
   AuthenticatorAttestationResponse,
   AuthenticatorSelectionCriteria,
   AuthenticatorTransport,
+  Base64URLString,
   COSEAlgorithmIdentifier,
   CredentialCreationOptions,
   CredentialRequestOptions,
@@ -183,11 +185,6 @@ export type WebAuthnCredential = {
   // From browser's `startRegistration()` -> RegistrationCredentialJSON.transports (API L2 and up)
   transports?: AuthenticatorTransportFuture[];
 };
-
-/**
- * An attempt to communicate that this isn't just any string, but a Base64URL-encoded string
- */
-export type Base64URLString = string;
 
 /**
  * AuthenticatorAttestationResponse in TypeScript's DOM lib is outdated (up through v3.9.7).

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,7 +10,6 @@ import type {
   COSEAlgorithmIdentifier,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
-  PublicKeyCredentialDescriptor,
   PublicKeyCredentialDescriptorJSON,
   PublicKeyCredentialParameters,
   PublicKeyCredentialRequestOptions,
@@ -96,7 +95,7 @@ export interface PublicKeyCredentialUserEntityJSON {
  * The value returned from navigator.credentials.create()
  */
 export interface RegistrationCredential extends PublicKeyCredentialFuture {
-  response: AuthenticatorAttestationResponseFuture;
+  response: AuthenticatorAttestationResponse;
 }
 
 /**
@@ -178,43 +177,6 @@ export type WebAuthnCredential = {
   // From browser's `startRegistration()` -> RegistrationCredential.response.transports (API L2 and up)
   transports?: string[];
 };
-
-/**
- * AuthenticatorAttestationResponse in TypeScript's DOM lib is outdated (up through v3.9.7).
- * Maintain an augmented version here so we can implement additional properties as the WebAuthn
- * spec evolves.
- *
- * See https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse
- *
- * Properties marked optional are not supported in all browsers.
- */
-export interface AuthenticatorAttestationResponseFuture extends AuthenticatorAttestationResponse {
-  getTransports(): AuthenticatorTransportFuture[];
-}
-
-/**
- * A super class of TypeScript's `AuthenticatorTransport` that includes support for the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export type AuthenticatorTransportFuture =
-  | 'ble'
-  | 'cable'
-  | 'hybrid'
-  | 'internal'
-  | 'nfc'
-  | 'smart-card'
-  | 'usb';
-
-/**
- * A super class of TypeScript's `PublicKeyCredentialDescriptor` that knows about the latest
- * transports. Should eventually be replaced by TypeScript's when TypeScript gets updated to
- * know about it (sometime after 4.6.3)
- */
-export interface PublicKeyCredentialDescriptorFuture
-  extends Omit<PublicKeyCredentialDescriptor, 'transports'> {
-  transports?: AuthenticatorTransportFuture[];
-}
 
 /** */
 export type PublicKeyCredentialJSON =

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -148,7 +148,7 @@ export interface AuthenticatorAttestationResponseJSON {
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   authenticatorData?: Base64URLString;
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
-  transports?: AuthenticatorTransportFuture[];
+  transports?: string[];
   // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
   publicKeyAlgorithm?: COSEAlgorithmIdentifier;
   publicKey?: Base64URLString;
@@ -175,8 +175,8 @@ export type WebAuthnCredential = {
   publicKey: Uint8Array_;
   // Number of times this authenticator is expected to have been used
   counter: number;
-  // From browser's `startRegistration()` -> RegistrationCredentialJSON.transports (API L2 and up)
-  transports?: AuthenticatorTransportFuture[];
+  // From browser's `startRegistration()` -> RegistrationCredential.response.transports (API L2 and up)
+  transports?: string[];
 };
 
 /**


### PR DESCRIPTION
This PR softens typing on `transports` to `string[]`. This is intended to make it easier to pass in TypeScript-DOM-lib-typed output from `navigator.credentials.create()` and `navigator.credentials.get()` into the various SimpleWebAuthn methods.

I will note to my future self that `transports` is generally typed as `string[]` in TypeScript types because that's what we typed it as over in the WAWG:

https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-gettransports

My trying to apply stricter typing to them here was to communicate what the possible transport values might be. But spec guidance instructs RPs to treat transports as "opaque values" (read: don't worry about them, just store them and pass them back to the browser.) I probably inadvertently made RPs too aware of what transports are by, for example, requiring casting to `as AuthenticatorTransportFuture[]` when crafting `excludeCredentials` and `allowCredentials`. That shouldn't be necessary anymore with these changes.

Fixes #768.