### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -19,11 +19,11 @@ jobs:
         deno-version: ['v2.1.x', 'v2.4.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Install Node
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Confirm installed Node version
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "DENO_DIR=$(deno info | grep "DENO_DIR" | awk '{print $3}')" >> $GITHUB_ENV
       - name: Setup Deno cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ runner.os }}-deno-dir-${{ hashFiles('**/deno.lock') }}

--- a/.github/workflows/publishBrowser.yml
+++ b/.github/workflows/publishBrowser.yml
@@ -16,11 +16,11 @@ jobs:
       DENO_VERSION: 'v2.4.x'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # Install Node
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "DENO_DIR=$(deno info | grep "DENO_DIR" | awk '{print $3}')" >> $GITHUB_ENV
       - name: Setup Deno cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ runner.os }}-deno-dir-${{ hashFiles('**/deno.lock') }}

--- a/.github/workflows/publishServer.yml
+++ b/.github/workflows/publishServer.yml
@@ -16,11 +16,11 @@ jobs:
       DENO_VERSION: 'v2.4.x'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # Install Node
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "DENO_DIR=$(deno info | grep "DENO_DIR" | awk '{print $3}')" >> $GITHUB_ENV
       - name: Setup Deno cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ runner.os }}-deno-dir-${{ hashFiles('**/deno.lock') }}


### PR DESCRIPTION
CI runs here are complaining about my continued use of actions that use the unsupported Node 20 runtime. This PR updates the offending steps to use newer versions of those actions.