### PR TITLE
Support "Immediate UI" for authentication

### DIFF
--- a/packages/browser/src/methods/startAuthentication.ts
+++ b/packages/browser/src/methods/startAuthentication.ts
@@ -20,12 +20,14 @@ export type StartAuthenticationOpts = Parameters<typeof startAuthentication>[0];
  * @param optionsJSON Output from **@simplewebauthn/server**'s `generateAuthenticationOptions()`
  * @param useBrowserAutofill (Optional) Initialize conditional UI to enable logging in via browser autofill prompts. Defaults to `false`.
  * @param verifyBrowserAutofillInput (Optional) Ensure a suitable `<input>` element is present when `useBrowserAutofill` is `true`. Defaults to `true`.
+ * @param useImmediateUIMode (Optional) Initialize immediate UI to enable logging in via the browser immediate UI. Defaults to `false`.
  */
 export async function startAuthentication(
   options: {
     optionsJSON: PublicKeyCredentialRequestOptionsJSON;
     useBrowserAutofill?: boolean;
     verifyBrowserAutofillInput?: boolean;
+    useImmediateUIMode?: boolean;
   },
 ): Promise<AuthenticationResponseJSON> {
   // @ts-ignore: Intentionally check for old call structure to warn about improper API call
@@ -42,7 +44,14 @@ export async function startAuthentication(
     optionsJSON,
     useBrowserAutofill = false,
     verifyBrowserAutofillInput = true,
+    useImmediateUIMode = false,
   } = options;
+
+  if (useImmediateUIMode && useBrowserAutofill) {
+    throw new Error(
+      'startAuthentication() was called with both `useImmediateUiMode` and `useBrowserAutofill` set to true. These options are mutually exclusive.',
+    );
+  }
 
   if (!browserSupportsWebAuthn()) {
     throw new Error('WebAuthn is not supported in this browser');
@@ -92,6 +101,18 @@ export async function startAuthentication(
     // typescript@4.6.3
     getOptions.mediation = 'conditional' as CredentialMediationRequirement;
     // Conditional UI requires an empty allow list
+    publicKey.allowCredentials = [];
+  }
+
+  /**
+   * Set up the page to prompt the user to select a credential for authentication via the browser's
+   * immediate UI mechanism.
+   */
+  if (useImmediateUIMode) {
+    // @ts-ignore: `uiMode` is not yet in TypeScript's DOM lib
+    getOptions.uiMode = 'immediate';
+
+    // Immediate UI requires an empty allow list
     publicKey.allowCredentials = [];
   }
 


### PR DESCRIPTION
This adds support for "Immediate UI" to the `startAuthentication` function by adding a new `useImmediateUIMode` option.

Here are some explainers for Immediate UI (but I'm sure you are already aware 😉):
 - https://developer.chrome.com/docs/identity/immediate-ui-mode?hl=en
 - https://developer.chrome.com/blog/webauthn-immediate-ui?hl=en
 - https://github.com/w3c/webauthn/blob/main/explainers/immediate-mediation.md
 
This might be too soon to add as only Chrome (but already stable) supports this and there is still some movement in the API. It might make more sense to land this once the API settles and might require some breaking changes to the options to allow different combinations of `uiMode` and `mediation`.

Let me know if you are open to add this yet or have any API changes, then I will take the time to add some tests.

---

A different approach might be to allow passing custom options that are spread into `getOptions` (or maybe a callback that gets called with the constructed `getOptions` and returns modified ones) so its the users responsibility to use APIs that are not yet natively supported by `startAuthentication`.