### PR TITLE
Use JWT header alg when verifying MDS blob

### DIFF
--- a/packages/server/src/helpers/mapJWSAlgToCOSEAlg.test.ts
+++ b/packages/server/src/helpers/mapJWSAlgToCOSEAlg.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals, assertThrows } from '@std/assert';
+import { mapJWSAlgToCOSEAlg } from './mapJWSAlgToCOSEAlg.ts';
+import { COSEALG } from './cose.ts';
+
+Deno.test('should map "ES256" to -7', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('ES256'), COSEALG.ES256);
+});
+
+Deno.test('should map "ES384" to -35', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('ES384'), COSEALG.ES384);
+});
+
+Deno.test('should map "ES512" to -36', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('ES512'), COSEALG.ES512);
+});
+
+Deno.test('should map "RS256" to -257', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('RS256'), COSEALG.RS256);
+});
+
+Deno.test('should map "RS384" to -7', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('RS384'), COSEALG.RS384);
+});
+
+Deno.test('should map "RS512" to -7', () => {
+  assertEquals(mapJWSAlgToCOSEAlg('RS512'), COSEALG.RS512);
+});
+
+Deno.test('should raise on unsupported JWS alg', () => {
+  assertThrows(() => {
+    mapJWSAlgToCOSEAlg('FOOALG');
+  });
+});

--- a/packages/server/src/helpers/mapJWSAlgToCOSEAlg.ts
+++ b/packages/server/src/helpers/mapJWSAlgToCOSEAlg.ts
@@ -1,0 +1,28 @@
+import { COSEALG } from './cose.ts';
+
+/**
+ * Map JWS algorithms to COSE algorithm IDs
+ *
+ * See https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1 for possible values
+ */
+export function mapJWSAlgToCOSEAlg(alg: string): COSEALG {
+  let algCOSE: COSEALG;
+
+  if (alg === 'ES256') {
+    algCOSE = COSEALG.ES256;
+  } else if (alg === 'ES384') {
+    algCOSE = COSEALG.ES384;
+  } else if (alg === 'ES512') {
+    algCOSE = COSEALG.ES512;
+  } else if (alg === 'RS256') {
+    algCOSE = COSEALG.RS256;
+  } else if (alg === 'RS384') {
+    algCOSE = COSEALG.RS384;
+  } else if (alg === 'RS512') {
+    algCOSE = COSEALG.RS512;
+  } else {
+    throw new Error(`Unable to map JWS algorithm "${alg}" to a COSE algorithm`);
+  }
+
+  return algCOSE;
+}

--- a/packages/server/src/metadata/verifyJWT.ts
+++ b/packages/server/src/metadata/verifyJWT.ts
@@ -1,6 +1,7 @@
 import { convertX509PublicKeyToCOSE } from '../helpers/convertX509PublicKeyToCOSE.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
 import { COSEALG, COSEKEYS, isCOSEPublicKeyEC2, isCOSEPublicKeyRSA } from '../helpers/cose.ts';
+import { mapJWSAlgToCOSEAlg } from '../helpers/mapJWSAlgToCOSEAlg.ts';
 import { verifyEC2 } from '../helpers/iso/isoCrypto/verifyEC2.ts';
 import { verifyRSA } from '../helpers/iso/isoCrypto/verifyRSA.ts';
 import type { Uint8Array_ } from '../types/index.ts';
@@ -21,18 +22,24 @@ export function verifyJWT(jwt: string, leafCert: Uint8Array_): Promise<boolean> 
   const data = isoUint8Array.fromUTF8String(`${header}.${payload}`);
   const signatureBytes = isoBase64URL.toBuffer(signature);
 
+  // We just need the `alg` from the header, so only partially define the shape of it
+  const headerJSON: { alg: string } = JSON.parse(isoBase64URL.toUTF8String(header));
+
+  const jwtHeaderHashAlgCOSE = mapJWSAlgToCOSEAlg(headerJSON.alg);
+
   if (isCOSEPublicKeyEC2(certCOSE)) {
     return verifyEC2({
       data,
       signature: signatureBytes,
       cosePublicKey: certCOSE,
-      shaHashOverride: COSEALG.ES256,
+      shaHashOverride: jwtHeaderHashAlgCOSE,
     });
   } else if (isCOSEPublicKeyRSA(certCOSE)) {
     return verifyRSA({
       data,
       signature: signatureBytes,
       cosePublicKey: certCOSE,
+      shaHashOverride: jwtHeaderHashAlgCOSE,
     });
   }
 


### PR DESCRIPTION
This PR fixes MDS blob verification to properly use the JWT header's `"alg"` property to determine which hash algorithm to use to verify the signature.

MDS blobs are too big to include as test data (10MB+) so I verified locally that this fixed the issue identified in #786 with the latest MDS blob from https://mds3.fidoalliance.org that has `"alg": "RS256"` in its header:

```ts
import { verifyMDSBlob } from './src/helpers/index.ts';

const blob = await Deno.readTextFile('./blob.jwt');

const verified = await verifyMDSBlob(blob);

console.log(verified.parsedNextUpdate);
// 2026-09-01T07:00:00.000Z
```

Fixes #786.