### PR TITLE
Use same default list of public key algorithm IDs when verifying registration responses

### DIFF
--- a/packages/server/src/helpers/index.ts
+++ b/packages/server/src/helpers/index.ts
@@ -15,4 +15,6 @@ export * from './verifySignature.ts';
 export * from './iso/index.ts';
 export * from '../metadata/verifyMDSBlob.ts';
 export * as cose from './cose.ts';
+// Specially exporting this for easier `supportedAlgorithmIDs` argument definition
+export { COSEALG } from './cose.ts';
 export { type SimpleWebAuthnLogger } from './logging.ts';

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -2,7 +2,6 @@ import type {
   AuthenticationExtensionsClientInputs,
   AuthenticatorSelectionCriteria,
   Base64URLString,
-  COSEAlgorithmIdentifier,
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialHint,
   PublicKeyCredentialParameters,
@@ -11,42 +10,9 @@ import type {
 import { generateChallenge } from '../helpers/generateChallenge.ts';
 import { generateUserID } from '../helpers/generateUserID.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
+import { COSEALG } from '../helpers/cose.ts';
 
 export type GenerateRegistrationOptionsOpts = Parameters<typeof generateRegistrationOptions>[0];
-
-/**
- * Supported crypto algo identifiers.
- * See https://w3c.github.io/webauthn/#sctn-alg-identifier
- * and https://www.iana.org/assignments/cose/cose.xhtml#algorithms
- */
-export const supportedCOSEAlgorithmIdentifiers: COSEAlgorithmIdentifier[] = [
-  // EdDSA (In first position to encourage authenticators to use this over ES256)
-  -8,
-  // ECDSA w/ SHA-256
-  -7,
-  // ECDSA w/ SHA-512
-  -36,
-  // RSASSA-PSS w/ SHA-256
-  -37,
-  // RSASSA-PSS w/ SHA-384
-  -38,
-  // RSASSA-PSS w/ SHA-512
-  -39,
-  // ML-DSA-44
-  -48,
-  // ML-DSA-65
-  -49,
-  // ML-DSA-87
-  -50,
-  // RSASSA-PKCS1-v1_5 w/ SHA-256
-  -257,
-  // RSASSA-PKCS1-v1_5 w/ SHA-384
-  -258,
-  // RSASSA-PKCS1-v1_5 w/ SHA-512
-  -259,
-  // RSASSA-PKCS1-v1_5 w/ SHA-1 (Deprecated; here for legacy support)
-  -65535,
-];
 
 /**
  * Set up some default authenticator selection options as per the latest spec:
@@ -66,7 +32,11 @@ const defaultAuthenticatorSelection: AuthenticatorSelectionCriteria = {
  *   - https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  *   - https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-pubkeycredparams
  */
-const defaultSupportedAlgorithmIDs: COSEAlgorithmIdentifier[] = [-8, -7, -257];
+export const defaultSupportedAlgorithmIDs: COSEALG[] = [
+  COSEALG.EdDSA,
+  COSEALG.ES256,
+  COSEALG.RS256,
+];
 
 /**
  * Prepare a value to pass into navigator.credentials.create(...) for authenticator registration
@@ -103,7 +73,7 @@ export async function generateRegistrationOptions(
     }[];
     authenticatorSelection?: AuthenticatorSelectionCriteria;
     extensions?: AuthenticationExtensionsClientInputs;
-    supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
+    supportedAlgorithmIDs?: COSEALG[];
     preferredAuthenticatorType?: 'securityKey' | 'localDevice' | 'remoteDevice';
   },
 ): Promise<PublicKeyCredentialCreationOptionsJSON> {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -54,7 +54,7 @@ export const defaultSupportedAlgorithmIDs: COSEALG[] = [
  * @param excludeCredentials **(Optional)** - Authenticators registered by the user so the user can't register the same credential multiple times. Defaults to `[]`
  * @param authenticatorSelection **(Optional)** - Advanced criteria for restricting the types of authenticators that may be used. Defaults to `{ residentKey: 'preferred', userVerification: 'preferred' }`
  * @param extensions **(Optional)** - Additional plugins the authenticator or browser should use during attestation
- * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers supported for attestation by this RP. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]`
+ * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]` (EdDSA, ES256, and RS256).
  * @param preferredAuthenticatorType **(Optional)** - Encourage the browser to prompt the user to register a specific type of authenticator
  */
 export async function generateRegistrationOptions(
@@ -73,7 +73,7 @@ export async function generateRegistrationOptions(
     }[];
     authenticatorSelection?: AuthenticatorSelectionCriteria;
     extensions?: AuthenticationExtensionsClientInputs;
-    supportedAlgorithmIDs?: COSEALG[];
+    supportedAlgorithmIDs?: number[];
     preferredAuthenticatorType?: 'securityKey' | 'localDevice' | 'remoteDevice';
   },
 ): Promise<PublicKeyCredentialCreationOptionsJSON> {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -54,7 +54,7 @@ export const defaultSupportedAlgorithmIDs: COSEALG[] = [
  * @param excludeCredentials **(Optional)** - Authenticators registered by the user so the user can't register the same credential multiple times. Defaults to `[]`
  * @param authenticatorSelection **(Optional)** - Advanced criteria for restricting the types of authenticators that may be used. Defaults to `{ residentKey: 'preferred', userVerification: 'preferred' }`
  * @param extensions **(Optional)** - Additional plugins the authenticator or browser should use during attestation
- * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]` (EdDSA, ES256, and RS256).
+ * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. Import `COSEALG` from \@simplewebauthn/server/helpers for suitable values. Defaults to `[COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256]`
  * @param preferredAuthenticatorType **(Optional)** - Encourage the browser to prompt the user to register a specific type of authenticator
  */
 export async function generateRegistrationOptions(

--- a/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
+++ b/packages/server/src/registration/verifications/tpm/verifyAttestationTPM.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertRejects } from '@std/assert';
 import { FakeTime } from '@std/testing/time';
 
 import { verifyRegistrationResponse } from '../../verifyRegistrationResponse.ts';
+import { COSEALG } from '../../../helpers/cose.ts';
 
 Deno.test('should verify TPM response', async () => {
   // Faking time to something that'll satisfy all of these ranges:
@@ -68,6 +69,7 @@ Deno.test('should verify SHA1 TPM response', async () => {
     expectedOrigin: 'https://localhost:44329',
     expectedRPID: 'localhost',
     requireUserVerification: false,
+    supportedAlgorithmIDs: [COSEALG.RS1],
   });
 
   assertEquals(verification.verified, true);

--- a/packages/server/src/registration/verifyRegistrationResponse.test.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.test.ts
@@ -17,7 +17,7 @@ import { _decodeCredentialPublicKeyInternals } from '../helpers/decodeCredential
 import { _verifySignatureInternals } from '../helpers/verifySignature.ts';
 import { toHash } from '../helpers/toHash.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
-import { COSEKEYS } from '../helpers/cose.ts';
+import { COSEALG, COSEKEYS } from '../helpers/cose.ts';
 import { SettingsService } from '../services/settingsService.ts';
 
 /**
@@ -673,6 +673,7 @@ Deno.test('should validate TPM RSA response (SHA1)', async () => {
     expectedOrigin: 'https://dev.dontneeda.pw',
     expectedRPID: 'dev.dontneeda.pw',
     requireUserVerification: false,
+    supportedAlgorithmIDs: [COSEALG.RS1],
   });
 
   assert(verification.verified);
@@ -1018,6 +1019,7 @@ Deno.test('should verify Packed attestation with RSA-PSS SHA-256 public key', as
     expectedOrigin: 'http://localhost:8000',
     expectedRPID: 'localhost',
     requireUserVerification: false,
+    supportedAlgorithmIDs: [COSEALG.PS256],
   });
 
   assert(verification.verified);
@@ -1042,6 +1044,7 @@ Deno.test('should verify Packed attestation with RSA-PSS SHA-384 public key', as
     expectedOrigin: 'http://localhost:8000',
     expectedRPID: 'localhost',
     requireUserVerification: false,
+    supportedAlgorithmIDs: [COSEALG.PS384],
   });
 
   assert(verification.verified);
@@ -1127,6 +1130,7 @@ Deno.test('should verify ML-DSA-44 registration response', async () => {
       '4l8disV6VitGCg_EJvCNx7V92QLtBn_RYq9tTBEZ7j4B5hZI9kijJ2InLxQNRYVlgLROF3nfj80Yi7MPhXQwjw',
     expectedOrigin: 'https://webauthn.io',
     expectedRPID: 'webauthn.io',
+    supportedAlgorithmIDs: [COSEALG.ML_DSA_44],
   });
 
   assert(verification.verified);
@@ -1151,6 +1155,7 @@ Deno.test('should verify ML-DSA-65 registration response', async () => {
       'rQM3_HtwB63gl8EoLqrM4iPCmQ3siW9U7Rutnw9qGMZT8lWAETIaZcFEw6j2Qw40fDGZW4QrbisBjoRbeXidLw',
     expectedOrigin: 'https://webauthn.io',
     expectedRPID: 'webauthn.io',
+    supportedAlgorithmIDs: [COSEALG.ML_DSA_65],
   });
 
   assert(verification.verified);
@@ -1175,6 +1180,7 @@ Deno.test('should verify ML-DSA-87 registration response', async () => {
       'JsGsBtHMYXARUIoR1rHvam63XDdRDzaLKbndrscpgU0qKFpJA0xeuv__ufk_5mgjIabEZneO9V32YWyMshWmEA',
     expectedOrigin: 'https://webauthn.io',
     expectedRPID: 'webauthn.io',
+    supportedAlgorithmIDs: [COSEALG.ML_DSA_87],
   });
 
   assert(verification.verified);

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -46,7 +46,7 @@ export type VerifyRegistrationResponseOpts = Parameters<typeof verifyRegistratio
  * @param expectedType **(Optional)** - The response type expected ('webauthn.create')
  * @param requireUserPresence **(Optional)** - Enforce user presence by the authenticator (or skip it during auto registration) Defaults to `true`
  * @param requireUserVerification **(Optional)** - Enforce user verification by the authenticator (via PIN, fingerprint, etc...) Defaults to `true`
- * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. Import `COSEALG` from \@simplewebauthn/server/helpers for suitable values. Defaults to `[COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256]`
+ * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. Import `COSEALG` from \@simplewebauthn/server/helpers for suitable values. Should be the same value that was specified for this same argument when calling `generateRegistrationOptions()`. Defaults to `[COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256]`
  * @param attestationSafetyNetEnforceCTSCheck **(Optional)** - Require that an Android device's system integrity has not been tampered with if it uses SafetyNet attestation. Defaults to `true`
  */
 export async function verifyRegistrationResponse(

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -46,7 +46,7 @@ export type VerifyRegistrationResponseOpts = Parameters<typeof verifyRegistratio
  * @param expectedType **(Optional)** - The response type expected ('webauthn.create')
  * @param requireUserPresence **(Optional)** - Enforce user presence by the authenticator (or skip it during auto registration) Defaults to `true`
  * @param requireUserVerification **(Optional)** - Enforce user verification by the authenticator (via PIN, fingerprint, etc...) Defaults to `true`
- * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]` (EdDSA, ES256, and RS256).
+ * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. Import `COSEALG` from \@simplewebauthn/server/helpers for suitable values. Defaults to `[COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256]`
  * @param attestationSafetyNetEnforceCTSCheck **(Optional)** - Require that an Android device's system integrity has not been tampered with if it uses SafetyNet attestation. Defaults to `true`
  */
 export async function verifyRegistrationResponse(

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -14,7 +14,7 @@ import { decodeClientDataJSON } from '../helpers/decodeClientDataJSON.ts';
 import { parseAuthenticatorData } from '../helpers/parseAuthenticatorData.ts';
 import { toHash } from '../helpers/toHash.ts';
 import { decodeCredentialPublicKey } from '../helpers/decodeCredentialPublicKey.ts';
-import { COSEALG, COSEKEYS } from '../helpers/cose.ts';
+import { COSEKEYS } from '../helpers/cose.ts';
 import { convertAAGUIDToString } from '../helpers/convertAAGUIDToString.ts';
 import { parseBackupFlags } from '../helpers/parseBackupFlags.ts';
 import { matchExpectedRPID } from '../helpers/matchExpectedRPID.ts';
@@ -46,7 +46,7 @@ export type VerifyRegistrationResponseOpts = Parameters<typeof verifyRegistratio
  * @param expectedType **(Optional)** - The response type expected ('webauthn.create')
  * @param requireUserPresence **(Optional)** - Enforce user presence by the authenticator (or skip it during auto registration) Defaults to `true`
  * @param requireUserVerification **(Optional)** - Enforce user verification by the authenticator (via PIN, fingerprint, etc...) Defaults to `true`
- * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers supported for attestation by this RP. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to all supported algorithm IDs
+ * @param supportedAlgorithmIDs **(Optional)** - Array of numeric COSE algorithm identifiers indicating supported public key algorithms. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms. Defaults to `[-8, -7, -257]` (EdDSA, ES256, and RS256).
  * @param attestationSafetyNetEnforceCTSCheck **(Optional)** - Require that an Android device's system integrity has not been tampered with if it uses SafetyNet attestation. Defaults to `true`
  */
 export async function verifyRegistrationResponse(
@@ -58,7 +58,7 @@ export async function verifyRegistrationResponse(
     expectedType?: string | string[];
     requireUserPresence?: boolean;
     requireUserVerification?: boolean;
-    supportedAlgorithmIDs?: COSEALG[];
+    supportedAlgorithmIDs?: number[];
     attestationSafetyNetEnforceCTSCheck?: boolean;
   },
 ): Promise<VerifiedRegistrationResponse> {

--- a/packages/server/src/registration/verifyRegistrationResponse.ts
+++ b/packages/server/src/registration/verifyRegistrationResponse.ts
@@ -1,5 +1,4 @@
 import type {
-  COSEAlgorithmIdentifier,
   CredentialDeviceType,
   RegistrationResponseJSON,
   Uint8Array_,
@@ -15,14 +14,14 @@ import { decodeClientDataJSON } from '../helpers/decodeClientDataJSON.ts';
 import { parseAuthenticatorData } from '../helpers/parseAuthenticatorData.ts';
 import { toHash } from '../helpers/toHash.ts';
 import { decodeCredentialPublicKey } from '../helpers/decodeCredentialPublicKey.ts';
-import { COSEKEYS } from '../helpers/cose.ts';
+import { COSEALG, COSEKEYS } from '../helpers/cose.ts';
 import { convertAAGUIDToString } from '../helpers/convertAAGUIDToString.ts';
 import { parseBackupFlags } from '../helpers/parseBackupFlags.ts';
 import { matchExpectedRPID } from '../helpers/matchExpectedRPID.ts';
 import { isoBase64URL } from '../helpers/iso/index.ts';
 import { SettingsService } from '../services/settingsService.ts';
 
-import { supportedCOSEAlgorithmIdentifiers } from './generateRegistrationOptions.ts';
+import { defaultSupportedAlgorithmIDs } from './generateRegistrationOptions.ts';
 import { verifyAttestationFIDOU2F } from './verifications/verifyAttestationFIDOU2F.ts';
 import { verifyAttestationPacked } from './verifications/verifyAttestationPacked.ts';
 import { verifyAttestationAndroidSafetyNet } from './verifications/verifyAttestationAndroidSafetyNet.ts';
@@ -59,7 +58,7 @@ export async function verifyRegistrationResponse(
     expectedType?: string | string[];
     requireUserPresence?: boolean;
     requireUserVerification?: boolean;
-    supportedAlgorithmIDs?: COSEAlgorithmIdentifier[];
+    supportedAlgorithmIDs?: COSEALG[];
     attestationSafetyNetEnforceCTSCheck?: boolean;
   },
 ): Promise<VerifiedRegistrationResponse> {
@@ -71,7 +70,7 @@ export async function verifyRegistrationResponse(
     expectedType,
     requireUserPresence = true,
     requireUserVerification = true,
-    supportedAlgorithmIDs = supportedCOSEAlgorithmIdentifiers,
+    supportedAlgorithmIDs = defaultSupportedAlgorithmIDs,
     attestationSafetyNetEnforceCTSCheck = true,
   } = options;
   const { id, rawId, type: credentialType, response: attestationResponse } = response;


### PR DESCRIPTION
This PR updates `verifyRegistrationResponse()` to default its `supportedAlgorithmIDs` argument to the same list of algorithm IDs that `generateRegistrationResponse()` uses, which right now is `[-8, -7, -257]` (EdDSA, ES256, and RS256.)

`supportedCOSEAlgorithmIdentifiers` is also dropped for `defaultSupportedAlgorithmIDs`, which is now an array of `COSEALG` ints instead of `COSEAlgorithmIdentifier` ints. Since this nets out to no change in typing there should be minimal breaking changes here.

`COSEALG` is now exported directly from **@simplewebauthn/server/helpers** so that RPs can import it to define alg IDs in a more readable way:

```ts
import { generateRegistrationOptions } from '@simplewebauthn/server';
import { COSEALG } from '@simplewebauthn/server/helpers';

const options = await generateRegistrationOptions({
  // ...
  supportedAlgorithmIDs: [COSEALG.ML_DSA_87, COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256],
});
```

Fixes #790.

## Breaking Change(?)

What _might_ be considered a **breaking change** here is if an RP specified a different list of algs for `supportedAlgorithmIDs` when calling `generateRegistrationOptions()` but doesn't specify this same list when calling `verifyRegistrationResponse()` because the latter "just worked." This would be caused by the old default, `supportedCOSEAlgorithmIdentifiers`, being a comprehensive list of algorithm IDs vs the new default, `defaultSupportedAlgorithmIDs`, that's a more limited list.

The fix would be to update the call to `verifyRegistrationResponse()` to set `supportedAlgorithmIDs` to the same value as when calling `generateRegistrationOptions()`.