### PR TITLE
Add ML-DSA-44 to default public key algorithms when runtime supports PQC

### DIFF
--- a/packages/browser/src/types/index.ts
+++ b/packages/browser/src/types/index.ts
@@ -9,6 +9,7 @@
  */
 // BEGIN CODEGEN
 import type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -18,6 +19,7 @@ import type {
   AuthenticatorSelectionCriteria,
   Base64URLString,
   COSEAlgorithmIdentifier,
+  KeyUsage,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptorJSON,
@@ -25,10 +27,12 @@ import type {
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
+  SubtleCrypto,
   UserVerificationRequirement,
 } from './dom.ts';
 
 export type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -420,3 +424,11 @@ export type SendSignalCurrentUserDetailsOpts = {
   /** An optional, longer user identifier, like a full name, account differentiator, etc... Defaults to `""` */
   userDisplayName?: string;
 };
+
+/**
+ * A super class of TypeScript's `SubtleCrypto` that knows about upcoming features
+ */
+export interface SubtleCryptoFuture extends SubtleCrypto {
+  /** https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports */
+  supports(operation: KeyUsage, algorithm: AlgorithmIdentifier, length?: number): boolean;
+}

--- a/packages/server/src/helpers/iso/isoCrypto/digest.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/digest.ts
@@ -1,5 +1,5 @@
 import type { COSEALG } from '../../cose.ts';
-import { mapCoseAlgToWebCryptoAlg } from './mapCoseAlgToWebCryptoAlg.ts';
+import { mapCoseAlgToWebCryptoHashAlgName } from './mapCoseAlgToWebCryptoHashAlgName.ts';
 import { getWebCrypto } from './getWebCrypto.ts';
 import type { Uint8Array_ } from '../../../types/index.ts';
 
@@ -15,7 +15,7 @@ export async function digest(
 ): Promise<Uint8Array_> {
   const WebCrypto = await getWebCrypto();
 
-  const subtleAlgorithm = mapCoseAlgToWebCryptoAlg(algorithm);
+  const subtleAlgorithm = mapCoseAlgToWebCryptoHashAlgName(algorithm);
 
   const hashed = await WebCrypto.subtle.digest(subtleAlgorithm, data);
 

--- a/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoHashAlgName.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoHashAlgName.ts
@@ -2,9 +2,12 @@ import { SubtleCryptoAlg } from './structs.ts';
 import { COSEALG } from '../../cose.ts';
 
 /**
- * Convert a COSE alg ID into a corresponding string value that WebCrypto APIs expect
+ * Convert a COSE alg ID into a corresponding hash algorithm string value that WebCrypto APIs expect
+ *
+ * Unless otherwise specified, mappings were referenced from
+ * https://w3c.github.io/webcrypto/#jwk-mapping-alg
  */
-export function mapCoseAlgToWebCryptoAlg(alg: COSEALG): SubtleCryptoAlg {
+export function mapCoseAlgToWebCryptoHashAlgName(alg: COSEALG): SubtleCryptoAlg {
   if ([COSEALG.RS1].indexOf(alg) >= 0) {
     return 'SHA-1';
   } else if ([COSEALG.ES256, COSEALG.PS256, COSEALG.RS256].indexOf(alg) >= 0) {
@@ -18,5 +21,5 @@ export function mapCoseAlgToWebCryptoAlg(alg: COSEALG): SubtleCryptoAlg {
     return 'SHA-512';
   }
 
-  throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto alg`);
+  throw new Error(`Could not map COSE alg value of ${alg} to a WebCrypto hash alg name`);
 }

--- a/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoHashAlgName.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/mapCoseAlgToWebCryptoHashAlgName.ts
@@ -1,4 +1,4 @@
-import { SubtleCryptoAlg } from './structs.ts';
+import type { SubtleCryptoAlg } from './structs.ts';
 import { COSEALG } from '../../cose.ts';
 
 /**

--- a/packages/server/src/helpers/iso/isoCrypto/runtimeSupportsWebCryptoKeyAlg.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/runtimeSupportsWebCryptoKeyAlg.ts
@@ -1,0 +1,19 @@
+import type { AlgorithmIdentifier, SubtleCryptoFuture } from '../../../types/index.ts';
+
+/**
+ * Use SubtleCrypto.supports() to understand if the runtime supports using the given key algorithm
+ * for signature verification.
+ */
+export function runtimeSupportsWebCryptoKeyAlg(alg: AlgorithmIdentifier): boolean {
+  const globalSubtleCrypto = globalThis.SubtleCrypto as unknown as SubtleCryptoFuture;
+
+  if (typeof globalSubtleCrypto.supports !== 'function') {
+    return false;
+  }
+
+  try {
+    return globalSubtleCrypto.supports('verify', alg);
+  } catch (_err) {
+    return false;
+  }
+}

--- a/packages/server/src/helpers/iso/isoCrypto/verifyEC2.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyEC2.ts
@@ -1,5 +1,5 @@
 import { type COSEALG, COSECRV, COSEKEYS, type COSEPublicKeyEC2 } from '../../cose.ts';
-import { mapCoseAlgToWebCryptoAlg } from './mapCoseAlgToWebCryptoAlg.ts';
+import { mapCoseAlgToWebCryptoHashAlgName } from './mapCoseAlgToWebCryptoHashAlgName.ts';
 import { importJWKKey } from './importJWKKey.ts';
 import { isoBase64URL } from '../index.ts';
 import type { SubtleCryptoCrv } from './structs.ts';
@@ -74,9 +74,9 @@ export async function verifyEC2(opts: {
   const key = await importJWKKey({ keyData, algorithm: keyAlgorithm });
 
   // Determine which SHA algorithm to use for signature verification
-  let subtleAlg = mapCoseAlgToWebCryptoAlg(alg);
+  let subtleAlg = mapCoseAlgToWebCryptoHashAlgName(alg);
   if (shaHashOverride) {
-    subtleAlg = mapCoseAlgToWebCryptoAlg(shaHashOverride);
+    subtleAlg = mapCoseAlgToWebCryptoHashAlgName(shaHashOverride);
   }
 
   const verifyAlgorithm: EcdsaParams = {

--- a/packages/server/src/helpers/iso/isoCrypto/verifyRSA.ts
+++ b/packages/server/src/helpers/iso/isoCrypto/verifyRSA.ts
@@ -1,5 +1,5 @@
 import { type COSEALG, COSEKEYS, type COSEPublicKeyRSA, isCOSEAlg } from '../../cose.ts';
-import { mapCoseAlgToWebCryptoAlg } from './mapCoseAlgToWebCryptoAlg.ts';
+import { mapCoseAlgToWebCryptoHashAlgName } from './mapCoseAlgToWebCryptoHashAlgName.ts';
 import { importJWKKey } from './importJWKKey.ts';
 import { isoBase64URL } from '../index.ts';
 import { mapCoseAlgToWebCryptoKeyAlgName } from './mapCoseAlgToWebCryptoKeyAlgName.ts';
@@ -49,7 +49,7 @@ export async function verifyRSA(opts: {
 
   const keyAlgorithm = {
     name: mapCoseAlgToWebCryptoKeyAlgName(alg),
-    hash: { name: mapCoseAlgToWebCryptoAlg(alg) },
+    hash: { name: mapCoseAlgToWebCryptoHashAlgName(alg) },
   };
 
   const verifyAlgorithm: AlgorithmIdentifier | RsaPssParams = {
@@ -57,7 +57,7 @@ export async function verifyRSA(opts: {
   };
 
   if (shaHashOverride) {
-    keyAlgorithm.hash.name = mapCoseAlgToWebCryptoAlg(shaHashOverride);
+    keyAlgorithm.hash.name = mapCoseAlgToWebCryptoHashAlgName(shaHashOverride);
   }
 
   if (keyAlgorithm.name === 'RSASSA-PKCS1-v1_5') {

--- a/packages/server/src/registration/generateRegistrationOptions.test.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from '@std/assert';
 import { returnsNext, stub } from '@std/testing/mock';
 import { Buffer } from 'node:buffer';
+import { greaterOrEqual, lessThan, parse } from '@std/semver';
 
 import { generateRegistrationOptions } from './generateRegistrationOptions.ts';
 import { _generateChallengeInternals } from '../helpers/generateChallenge.ts';
@@ -27,40 +28,68 @@ Deno.test('should generate credential request options suitable for sending via J
     attestationType,
   });
 
-  assertEquals(
-    options,
-    {
-      // Challenge, base64url-encoded
-      challenge: 'dG90YWxseXJhbmRvbXZhbHVl',
-      rp: {
-        name: rpName,
-        id: rpID,
-      },
-      user: {
-        id: isoBase64URL.fromBuffer(userID),
-        name: userName,
-        displayName: userDisplayName,
-      },
-      pubKeyCredParams: [
-        { alg: -8, type: 'public-key' },
-        { alg: -7, type: 'public-key' },
-        { alg: -257, type: 'public-key' },
-      ],
-      timeout,
-      attestation: attestationType,
-      excludeCredentials: [],
-      authenticatorSelection: {
-        requireResidentKey: false,
-        residentKey: 'preferred',
-        userVerification: 'preferred',
-      },
-      extensions: {
-        credProps: true,
-      },
-      hints: [],
-    },
-  );
+  assertEquals(options.challenge, 'dG90YWxseXJhbmRvbXZhbHVl');
+  assertEquals(options.rp, {
+    name: rpName,
+    id: rpID,
+  });
+  assertEquals(options.user, {
+    id: isoBase64URL.fromBuffer(userID),
+    name: userName,
+    displayName: userDisplayName,
+  });
+  assertEquals(options.timeout, timeout);
+  assertEquals(options.attestation, attestationType);
+  assertEquals(options.excludeCredentials, []);
+  assertEquals(options.authenticatorSelection, {
+    requireResidentKey: false,
+    residentKey: 'preferred',
+    userVerification: 'preferred',
+  });
+  assertEquals(options.extensions, {
+    credProps: true,
+  });
+  assertEquals(options.hints, []);
+  // I'm not checking pubKeyCredParams here because that gets tested in tests below that also check
+  // for inclusion of ML-DSA-44 in runtimes that support PQC
 });
+
+Deno.test(
+  'should add ML-DSA-44 to pubKeyCredParams when runtime supports PQC',
+  { ignore: lessThan(parse(Deno.version.deno), parse('2.8.2')) },
+  async () => {
+    const options = await generateRegistrationOptions({
+      rpID: 'not.real',
+      rpName: 'SimpleWebAuthn',
+      userName: 'usernameHere',
+    });
+
+    assertEquals(options.pubKeyCredParams, [
+      { alg: -48, type: 'public-key' },
+      { alg: -8, type: 'public-key' },
+      { alg: -7, type: 'public-key' },
+      { alg: -257, type: 'public-key' },
+    ]);
+  },
+);
+
+Deno.test(
+  'should not add ML-DSA-44 to pubKeyCredParams when runtime does not support PQC',
+  { ignore: greaterOrEqual(parse(Deno.version.deno), parse('2.8.2')) },
+  async () => {
+    const options = await generateRegistrationOptions({
+      rpID: 'not.real',
+      rpName: 'SimpleWebAuthn',
+      userName: 'usernameHere',
+    });
+
+    assertEquals(options.pubKeyCredParams, [
+      { alg: -8, type: 'public-key' },
+      { alg: -7, type: 'public-key' },
+      { alg: -257, type: 'public-key' },
+    ]);
+  },
+);
 
 Deno.test('should map excluded credential IDs if specified', async () => {
   const options = await generateRegistrationOptions({
@@ -309,17 +338,6 @@ Deno.test('should set requireResidentKey to false if residentKey if set to disco
 
   assertEquals(options.authenticatorSelection?.requireResidentKey, false);
   assertEquals(options.authenticatorSelection?.residentKey, 'discouraged');
-});
-
-Deno.test('should prefer Ed25519 in pubKeyCredParams', async () => {
-  const options = await generateRegistrationOptions({
-    rpName: 'SimpleWebAuthn',
-    rpID: 'not.real',
-    challenge: 'totallyrandomvalue',
-    userName: 'usernameHere',
-  });
-
-  assertEquals(options.pubKeyCredParams[0].alg, -8);
 });
 
 Deno.test('should raise if string is specified for userID', async () => {

--- a/packages/server/src/registration/generateRegistrationOptions.ts
+++ b/packages/server/src/registration/generateRegistrationOptions.ts
@@ -7,6 +7,7 @@ import type {
   PublicKeyCredentialParameters,
   Uint8Array_,
 } from '../types/index.ts';
+import { SettingsService } from '../services/settingsService.ts';
 import { generateChallenge } from '../helpers/generateChallenge.ts';
 import { generateUserID } from '../helpers/generateUserID.ts';
 import { isoBase64URL, isoUint8Array } from '../helpers/iso/index.ts';
@@ -32,11 +33,15 @@ const defaultAuthenticatorSelection: AuthenticatorSelectionCriteria = {
  *   - https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  *   - https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-pubkeycredparams
  */
-export const defaultSupportedAlgorithmIDs: COSEALG[] = [
+export let defaultSupportedAlgorithmIDs: COSEALG[] = [
   COSEALG.EdDSA,
   COSEALG.ES256,
   COSEALG.RS256,
 ];
+
+if (SettingsService.runtimeSupportsPQC()) {
+  defaultSupportedAlgorithmIDs = [COSEALG.ML_DSA_44, ...defaultSupportedAlgorithmIDs];
+}
 
 /**
  * Prepare a value to pass into navigator.credentials.create(...) for authenticator registration

--- a/packages/server/src/services/settingsService.ts
+++ b/packages/server/src/services/settingsService.ts
@@ -1,6 +1,7 @@
 import type { AttestationFormat } from '../helpers/decodeAttestationObject.ts';
 import { convertCertBufferToPEM } from '../helpers/convertCertBufferToPEM.ts';
 import type { Uint8Array_ } from '../types/index.ts';
+import { runtimeSupportsWebCryptoKeyAlg } from '../helpers/iso/isoCrypto/runtimeSupportsWebCryptoKeyAlg.ts';
 
 import { GlobalSign_Root_CA } from './defaultRootCerts/android-safetynet.ts';
 import {
@@ -31,14 +32,23 @@ interface SettingsService {
    * Get any registered root certificates for the specified attestation format
    */
   getRootCertificates(opts: { identifier: RootCertIdentifier }): string[];
+
+  /**
+   * Get the runtime's ability to support PQC algorithms by detecting support for ML-DSA-44
+   */
+  runtimeSupportsPQC(): boolean;
 }
 
 class BaseSettingsService implements SettingsService {
   // Certificates are stored as PEM-formatted strings
   private pemCertificates: Map<RootCertIdentifier, string[]>;
+  // Track whether the runtime supports PQC algorithms
+  private _runtimeSupportsPQC = false;
 
   constructor() {
     this.pemCertificates = new Map();
+    this._runtimeSupportsPQC = runtimeSupportsWebCryptoKeyAlg('ML-DSA-44');
+    console.log({ runtimeSupportsPQC: this._runtimeSupportsPQC });
   }
 
   setRootCertificates(opts: {
@@ -62,6 +72,10 @@ class BaseSettingsService implements SettingsService {
   getRootCertificates(opts: { identifier: RootCertIdentifier }): string[] {
     const { identifier } = opts;
     return this.pemCertificates.get(identifier) ?? [];
+  }
+
+  runtimeSupportsPQC() {
+    return this._runtimeSupportsPQC;
   }
 }
 

--- a/packages/server/src/services/settingsService.ts
+++ b/packages/server/src/services/settingsService.ts
@@ -48,7 +48,6 @@ class BaseSettingsService implements SettingsService {
   constructor() {
     this.pemCertificates = new Map();
     this._runtimeSupportsPQC = runtimeSupportsWebCryptoKeyAlg('ML-DSA-44');
-    console.log({ runtimeSupportsPQC: this._runtimeSupportsPQC });
   }
 
   setRootCertificates(opts: {

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -9,6 +9,7 @@
  */
 // BEGIN CODEGEN
 import type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -18,6 +19,7 @@ import type {
   AuthenticatorSelectionCriteria,
   Base64URLString,
   COSEAlgorithmIdentifier,
+  KeyUsage,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptorJSON,
@@ -25,10 +27,12 @@ import type {
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
+  SubtleCrypto,
   UserVerificationRequirement,
 } from './dom.ts';
 
 export type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -420,3 +424,11 @@ export type SendSignalCurrentUserDetailsOpts = {
   /** An optional, longer user identifier, like a full name, account differentiator, etc... Defaults to `""` */
   userDisplayName?: string;
 };
+
+/**
+ * A super class of TypeScript's `SubtleCrypto` that knows about upcoming features
+ */
+export interface SubtleCryptoFuture extends SubtleCrypto {
+  /** https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports */
+  supports(operation: KeyUsage, algorithm: AlgorithmIdentifier, length?: number): boolean;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -8,6 +9,7 @@ import type {
   AuthenticatorSelectionCriteria,
   Base64URLString,
   COSEAlgorithmIdentifier,
+  KeyUsage,
   PublicKeyCredential,
   PublicKeyCredentialCreationOptions,
   PublicKeyCredentialDescriptorJSON,
@@ -15,10 +17,12 @@ import type {
   PublicKeyCredentialRequestOptions,
   PublicKeyCredentialRpEntity,
   PublicKeyCredentialType,
+  SubtleCrypto,
   UserVerificationRequirement,
 } from './dom.ts';
 
 export type {
+  AlgorithmIdentifier,
   AttestationConveyancePreference,
   AuthenticationExtensionsClientInputs,
   AuthenticationExtensionsClientOutputs,
@@ -410,3 +414,11 @@ export type SendSignalCurrentUserDetailsOpts = {
   /** An optional, longer user identifier, like a full name, account differentiator, etc... Defaults to `""` */
   userDisplayName?: string;
 };
+
+/**
+ * A super class of TypeScript's `SubtleCrypto` that knows about upcoming features
+ */
+export interface SubtleCryptoFuture extends SubtleCrypto {
+  /** https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports */
+  supports(operation: KeyUsage, algorithm: AlgorithmIdentifier, length?: number): boolean;
+}


### PR DESCRIPTION
This PR includes ML-DSA-44 (`-48`) as the first algorithm in the default list of algorithms that become `pubKeyCredParams` when `generateRegistrationOptions()` is called and the runtime supports PQC algorithms.

This means that Relying Parties that **do not** specify `supportedAlgorithmIDs` when calling `generateRegistrationOptions()` will begin automatically requesting PQC ML-DSA-44 passkeys so long as the server running @simplewebauthn/server is in a supported runtime:

- **Node:** v24.7.0 and up
- **Deno:** v2.8.2 and up

The number of FIDO2 authenticators/credential managers that support PQC algorithms is basically non-existent as of August 2026 so the impact of this will be minimal. However as these solutions come online then Relying Parties using one of the runtimes above with PQC support can start benefitting from PQC algorithms without needing to make any additional changes.

And `SettingsService.runtimeSupportsPQC()` can now be called to understand if the runtime reports support for at least ML-DSA-44. Support for this algorithm is usually indicative of a runtime that supports at least ML-DSA-65 and ML-DSA-87 as well, which are the relevant PQC algorithms for WebAuthn.

Fixes #793.