### PR TITLE
Make certificate path validation more flexible

### DIFF
--- a/packages/server/src/helpers/tests/x509Utils.ts
+++ b/packages/server/src/helpers/tests/x509Utils.ts
@@ -51,6 +51,61 @@ export async function generateRootCert(opts: {
 }
 
 /**
+ * Generate a cert that is signed by another cert and can sign other certs to form a chain
+ */
+export async function generateIntermediateCert(
+  opts: {
+    /** Before when the cert should not be valid */
+    notBefore: Date;
+    /** After when the cert should not be valid */
+    notAfter: Date;
+    /** The certificate (and its keys) that this certificate will chain to */
+    issuer: { certificate: x509.X509Certificate; keys: CryptoKeyPair };
+    /** The optional subject for this certificate */
+    subject?: { certificate: x509.X509Certificate; keys: CryptoKeyPair };
+    /** The algorithm used for the certificate's keypair */
+    keyAlgorithm?: EcKeyGenParams;
+    /** The algorithm used for generating a signature over the certificate */
+    signingAlgorithm?: Algorithm | EcdsaParams;
+  },
+): Promise<{ certificate: x509.X509Certificate; keys: CryptoKeyPair }> {
+  const {
+    notBefore,
+    notAfter,
+    issuer,
+    subject,
+    keyAlgorithm = defaultKeyAlgorithm,
+    signingAlgorithm = defaultSigningAlgorithm,
+  } = opts;
+
+  const webCrypto = await getWebCrypto();
+
+  const certSubject = subject?.certificate.subject ??
+    'CN=SimpleWebAuthn Unit Test Intermediate Cert';
+
+  // Use the provided keys, otherwise generate a new keypair
+  const certKeys = subject?.keys ??
+    await webCrypto.subtle.generateKey(keyAlgorithm, false, ['sign', 'verify']);
+
+  const certificate = await x509.X509CertificateGenerator.create({
+    subject: certSubject,
+    notBefore,
+    notAfter,
+    issuer: issuer.certificate.subject,
+    signingKey: issuer.keys.privateKey,
+    signingAlgorithm,
+    publicKey: certKeys.publicKey,
+    extensions: [
+      // Explicitly state this cert can sign other certs
+      new x509.BasicConstraintsExtension(true, undefined, true),
+      new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+    ],
+  });
+
+  return { certificate, keys: certKeys };
+}
+
+/**
  * Generate an X.509 end-entity "leaf" certificate
  */
 export async function generateLeafCert(opts: {

--- a/packages/server/src/helpers/tests/x509Utils.ts
+++ b/packages/server/src/helpers/tests/x509Utils.ts
@@ -47,10 +47,7 @@ export async function generateRootCert(opts: {
     ],
   });
 
-  return {
-    certificate,
-    keys,
-  };
+  return { certificate, keys };
 }
 
 /**
@@ -71,7 +68,7 @@ export async function generateLeafCert(opts: {
   keyAlgorithm?: EcKeyGenParams;
   /** The algorithm used for generating a signature over the certificate */
   signingAlgorithm?: Algorithm | EcdsaParams;
-}): Promise<x509.X509Certificate> {
+}): Promise<{ certificate: x509.X509Certificate; keys: CryptoKeyPair }> {
   const {
     notBefore,
     notAfter,
@@ -100,5 +97,5 @@ export async function generateLeafCert(opts: {
     ],
   });
 
-  return certificate;
+  return { certificate, keys };
 }

--- a/packages/server/src/helpers/tests/x509Utils.ts
+++ b/packages/server/src/helpers/tests/x509Utils.ts
@@ -113,10 +113,8 @@ export async function generateLeafCert(opts: {
   notBefore: Date;
   /** After when the cert should not be valid */
   notAfter: Date;
-  /** The certificate that this certificate will chain to */
-  chainsToCertificate: x509.X509Certificate;
-  /** The private key of the `chainsToCertificate` certificate */
-  chainsToPrivateKey: CryptoKey;
+  /** The certificate (and its keys) that this certificate will chain to */
+  issuer: { certificate: x509.X509Certificate; keys: CryptoKeyPair };
   /** The Subject for this certificate */
   subject?: string;
   /** The algorithm used for the certificate's keypair */
@@ -127,8 +125,7 @@ export async function generateLeafCert(opts: {
   const {
     notBefore,
     notAfter,
-    chainsToCertificate,
-    chainsToPrivateKey,
+    issuer,
     subject = 'CN=SimpleWebAuthn Unit Test Leaf Cert',
     keyAlgorithm = defaultKeyAlgorithm,
     signingAlgorithm = defaultSigningAlgorithm,
@@ -141,12 +138,12 @@ export async function generateLeafCert(opts: {
     subject,
     notBefore,
     notAfter,
-    issuer: chainsToCertificate.subject,
-    signingKey: chainsToPrivateKey,
+    issuer: issuer.certificate.subject,
+    signingKey: issuer.keys.privateKey,
     signingAlgorithm,
     publicKey: keys.publicKey,
     extensions: [
-      // Explicitly state this is an end-entity (not a CA)
+      // Explicitly state this is an end-entity and thus cannot sign other certs
       new x509.BasicConstraintsExtension(false, undefined, true),
       new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
     ],

--- a/packages/server/src/helpers/tests/x509Utils.ts
+++ b/packages/server/src/helpers/tests/x509Utils.ts
@@ -41,7 +41,7 @@ export async function generateRootCert(opts: {
     signingAlgorithm,
     keys: keys,
     extensions: [
-      // Critical: Tell the world this is a CA and can sign things
+      // Critical: Tell the world this is a CA cert that can sign other certs
       new x509.BasicConstraintsExtension(true, undefined, true),
       new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
     ],

--- a/packages/server/src/helpers/validateCertificatePath.test.ts
+++ b/packages/server/src/helpers/validateCertificatePath.test.ts
@@ -204,7 +204,7 @@ Deno.test('should raise when x5c does not chain to trust anchor', async () => {
   );
 });
 
-Deno.test('should build valid path from partial list of x5c entries and anchor', async () => {
+Deno.test('should validate path from partial list of x5c entries to anchor', async () => {
   using _fakedNow = new FakeTime(new Date('2026-08-30'));
 
   const notBefore = new Date('2026-08-29');

--- a/packages/server/src/helpers/validateCertificatePath.test.ts
+++ b/packages/server/src/helpers/validateCertificatePath.test.ts
@@ -47,7 +47,7 @@ Deno.test('should reject x5c containing self-signed root certificate', async () 
     () =>
       validateCertificatePath(
         // x5c
-        [maliciousLeafCert.toString(), maliciousRoot.certificate.toString()],
+        [maliciousLeafCert.certificate.toString(), maliciousRoot.certificate.toString()],
         // trust anchors
         [realTrustAnchor.certificate.toString()],
       ),
@@ -71,7 +71,7 @@ Deno.test('should validate valid certificate chain', async () => {
   });
 
   const validated = await validateCertificatePath(
-    [leafCert.toString()],
+    [leafCert.certificate.toString()],
     [rootCert.certificate.toString()],
   );
 
@@ -95,7 +95,7 @@ Deno.test('should raise on not-yet-valid leaf certificate', async () => {
   await assertRejects(
     () =>
       validateCertificatePath(
-        [leafCert.toString()],
+        [leafCert.certificate.toString()],
         [rootCert.certificate.toString()],
       ),
     Error,
@@ -123,7 +123,7 @@ Deno.test('should raise on not-yet-valid trust anchor certificate', async () => 
   await assertRejects(
     () =>
       validateCertificatePath(
-        [leafCert.toString()],
+        [leafCert.certificate.toString()],
         [rootCert.certificate.toString()],
       ),
     Error,
@@ -148,7 +148,7 @@ Deno.test('should raise on expired leaf certificate', async () => {
   await assertRejects(
     () =>
       validateCertificatePath(
-        [leafCert.toString()],
+        [leafCert.certificate.toString()],
         [rootCert.certificate.toString()],
       ),
     Error,
@@ -176,7 +176,7 @@ Deno.test('should raise on expired trust anchor certificate', async () => {
   await assertRejects(
     () =>
       validateCertificatePath(
-        [leafCert.toString()],
+        [leafCert.certificate.toString()],
         [rootCert.certificate.toString()],
       ),
     Error,
@@ -203,7 +203,7 @@ Deno.test('should raise when x5c does not chain to trust anchor', async () => {
   await assertRejects(
     () =>
       validateCertificatePath(
-        [leafCert1.toString()],
+        [leafCert1.certificate.toString()],
         [rootCert2.certificate.toString()],
       ),
     Error,

--- a/packages/server/src/helpers/validateCertificatePath.test.ts
+++ b/packages/server/src/helpers/validateCertificatePath.test.ts
@@ -2,7 +2,7 @@ import { assert, assertRejects } from '@std/assert';
 import { FakeTime } from '@std/testing/time';
 
 import { validateCertificatePath } from './validateCertificatePath.ts';
-import { generateLeafCert, generateRootCert } from './tests/x509Utils.ts';
+import { generateIntermediateCert, generateLeafCert, generateRootCert } from './tests/x509Utils.ts';
 
 Deno.test('should reject x5c containing self-signed root certificate', async () => {
   /**
@@ -202,4 +202,57 @@ Deno.test('should raise when x5c does not chain to trust anchor', async () => {
     Error,
     'x5c could not be chained',
   );
+});
+
+Deno.test('should build valid path from partial list of x5c entries and anchor', async () => {
+  using _fakedNow = new FakeTime(new Date('2026-08-30'));
+
+  const notBefore = new Date('2026-08-29');
+  const notAfter = new Date('2026-08-31');
+
+  /**
+   * The cert chain being crafted here:
+   *
+   * leaf cert
+   * v
+   * intermediate cert
+   * v
+   * r46 CA cert
+   * v
+   * cross-sign cert
+   * v
+   * r3 CA cert
+   */
+
+  const rootCert3 = await generateRootCert({ notBefore, notAfter });
+  const rootCert46 = await generateRootCert({ notBefore, notAfter });
+
+  const crossSignCertR46ToR3 = await generateIntermediateCert({
+    notBefore,
+    notAfter,
+    subject: rootCert46,
+    issuer: rootCert3,
+  });
+
+  const intermediateCert = await generateIntermediateCert({
+    notBefore,
+    notAfter,
+    issuer: rootCert46,
+  });
+
+  const leafCert = await generateLeafCert({
+    notBefore,
+    notAfter,
+    issuer: intermediateCert,
+  });
+
+  const x5c = [
+    leafCert.certificate.toString(),
+    intermediateCert.certificate.toString(),
+    crossSignCertR46ToR3.certificate.toString(),
+  ];
+
+  // Ensure that both root certs can form a valid chain from x5c
+  assert(await validateCertificatePath(x5c, [rootCert46.certificate.toString()]));
+  assert(await validateCertificatePath(x5c, [rootCert3.certificate.toString()]));
 });

--- a/packages/server/src/helpers/validateCertificatePath.test.ts
+++ b/packages/server/src/helpers/validateCertificatePath.test.ts
@@ -33,8 +33,7 @@ Deno.test('should reject x5c containing self-signed root certificate', async () 
     subject: 'CN=Malicious Unit Test Leaf Cert',
     notBefore,
     notAfter,
-    chainsToCertificate: maliciousRoot.certificate,
-    chainsToPrivateKey: maliciousRoot.keys.privateKey,
+    issuer: maliciousRoot,
   });
 
   const realTrustAnchor = await generateRootCert({
@@ -66,8 +65,7 @@ Deno.test('should validate valid certificate chain', async () => {
   const leafCert = await generateLeafCert({
     notBefore,
     notAfter,
-    chainsToCertificate: rootCert.certificate,
-    chainsToPrivateKey: rootCert.keys.privateKey,
+    issuer: rootCert,
   });
 
   const validated = await validateCertificatePath(
@@ -88,8 +86,7 @@ Deno.test('should raise on not-yet-valid leaf certificate', async () => {
   const leafCert = await generateLeafCert({
     notBefore: new Date('2026-06-09'), // <-- later than _fakedNow
     notAfter,
-    chainsToCertificate: rootCert.certificate,
-    chainsToPrivateKey: rootCert.keys.privateKey,
+    issuer: rootCert,
   });
 
   await assertRejects(
@@ -116,8 +113,7 @@ Deno.test('should raise on not-yet-valid trust anchor certificate', async () => 
   const leafCert = await generateLeafCert({
     notBefore,
     notAfter,
-    chainsToCertificate: rootCert.certificate,
-    chainsToPrivateKey: rootCert.keys.privateKey,
+    issuer: rootCert,
   });
 
   await assertRejects(
@@ -141,8 +137,7 @@ Deno.test('should raise on expired leaf certificate', async () => {
   const leafCert = await generateLeafCert({
     notBefore,
     notAfter: new Date('2026-06-07'), // <-- earlier than _fakedNow
-    chainsToCertificate: rootCert.certificate,
-    chainsToPrivateKey: rootCert.keys.privateKey,
+    issuer: rootCert,
   });
 
   await assertRejects(
@@ -169,8 +164,7 @@ Deno.test('should raise on expired trust anchor certificate', async () => {
   const leafCert = await generateLeafCert({
     notBefore,
     notAfter,
-    chainsToCertificate: rootCert.certificate,
-    chainsToPrivateKey: rootCert.keys.privateKey,
+    issuer: rootCert,
   });
 
   await assertRejects(
@@ -194,8 +188,7 @@ Deno.test('should raise when x5c does not chain to trust anchor', async () => {
   const leafCert1 = await generateLeafCert({
     notBefore,
     notAfter,
-    chainsToCertificate: rootCert1.certificate,
-    chainsToPrivateKey: rootCert1.keys.privateKey,
+    issuer: rootCert1,
   });
 
   const rootCert2 = await generateRootCert({ notBefore, notAfter });

--- a/packages/server/src/helpers/validateCertificatePath.ts
+++ b/packages/server/src/helpers/validateCertificatePath.ts
@@ -93,17 +93,37 @@ export async function validateCertificatePath(
 
       // Order of certs doesn't matter here but for readability
       const chainBuilder = new X509ChainBuilder({ certificates: [...x5cIntermediates, anchor] });
-      // Cert chain should be, from index 0: leaf cert -> ...intermediates -> trust anchor
+      // Attempt to build a certificate path
       const chain = await chainBuilder.build(x5cLeafCert);
 
-      // Check if the chain contains (all of the certs in x5c) + (the trust anchor)
-      if (chain.length < numUniqueCerts) {
-        // Invalid cert chain, try the next trust anchor
-        continue;
+      /**
+       * The cert chain must chain to the anchor. Usually this is as simple as asserting that the
+       * final cert in the chain is the anchor cert. However there's an odd scenario where an
+       * intermediate certificate can chain to an anchor cert's public key, but not actually to the
+       * anchor cert because e.g. the chain builder stopped at a cross-signed cert for the anchor
+       * and not the anchor cert itself.
+       *
+       * So here we're going to check for that. In the simplest case we'll be fine with the last
+       * cert in the chain being byte-equivalent to the current anchor cert. If not, then move a
+       * cert up the chain and explicitly check that it was signed by the anchor cert. This also
+       * future-proofs this logic from the internals of whatever future X.509 library might be used
+       * to build the cert path.
+       */
+      const lastCert = chain[chain.length - 1];
+      const lastCertEqualsAnchor: boolean = lastCert.equal(anchor);
+
+      let certBeforeLastSignedByAnchor = false;
+      if (!lastCertEqualsAnchor && chain.length > 1) {
+        const certBeforeLast = chain[chain.length - 2];
+        certBeforeLastSignedByAnchor = await certBeforeLast.verify({
+          publicKey: anchor.publicKey,
+          signatureOnly: true,
+        });
       }
 
-      // Check if the chain is to the trust anchor
-      if (chain[chain.length - 1].subject !== anchor.subject) {
+      const chainReachesAnchor = lastCertEqualsAnchor || certBeforeLastSignedByAnchor;
+
+      if (!chainReachesAnchor) {
         // Invalid cert chain, try the next trust anchor
         continue;
       }


### PR DESCRIPTION
This PR fixes a weakness in `validateCertificatePath()` which assumed that every cert in `x5c` must be a part of the path. Instead it'll ensure that a valid path, put together from the entries in `x5c`, chains to the anchor cert whether the path used all the certs in `x5c` or not.

For some context for myself later, FIDO MDS recently included a cross-signed certificate in its JWT header's `x5c`. This cert allows RPs to continue to support the use of Global Sign R3 for blob signature verification while MDS migrates to using Global Sign R46 longer-term. This is what revealed the weakness being fixed here.

Fixes #795.